### PR TITLE
DOCSP-20958: update default values to monospace

### DIFF
--- a/source/source-connector/configuration-properties/kafka-topic.txt
+++ b/source/source-connector/configuration-properties/kafka-topic.txt
@@ -47,7 +47,7 @@ Settings
 
           :ref:`Topic Naming Prefix Usage Example <source-usage-example-topic-naming>`
 
-       | **Default**: ""
+       | **Default**: ``""``
        | **Accepted Values**: A string composed of ASCII alphanumeric
          characters including ".", "-", and "_"
 
@@ -62,7 +62,7 @@ Settings
 
           :ref:`Topic Naming Suffix Usage Example <source-usage-example-topic-naming>`
 
-       | **Default**: ""
+       | **Default**: ``""``
        | **Accepted Values**: A string composed of ASCII alphanumeric
          characters including ".", "-", and "_"
 

--- a/source/source-connector/configuration-properties/mongodb-connection.txt
+++ b/source/source-connector/configuration-properties/mongodb-connection.txt
@@ -58,7 +58,7 @@ Settings
        | Name of the database to watch for changes. If not set, the connector
          watches all databases for changes.
        |
-       | **Default**: ""
+       | **Default**: ``""``
        | **Accepted Values**: A single database name
 
    * - | **collection**
@@ -74,7 +74,7 @@ Settings
           ignores the ``collection`` setting.
 
        |
-       | **Default**: ""
+       | **Default**: ``""``
        | **Accepted Values**: A single collection name
 
    * - **server.api.version**


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/10gen/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-20958>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-20958-monospace-default-values/source-connector/configuration-properties/all-properties/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
