### PR TITLE
remove link to 10gen repo in pr review template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Pull Request Info
 
-[PR Reviewing Guidelines](https://github.com/10gen/docs-kafka-connector/blob/master/REVIEWING.md)
+[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)
 
 JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
 Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>


### PR DESCRIPTION
# Pull Request Info

Fix link to 10gen repo in PR template

[PR Reviewing Guidelines](https://github.com/10gen/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - None

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
