### PR TITLE
(DOCSP-22974) Move Connector Info

### DIFF
--- a/source/includes/source-connector-change-stream.rst
+++ b/source/includes/source-connector-change-stream.rst
@@ -1,4 +1,4 @@
-A {+mkc+} source connector works by opening a single change stream with
-MongoDB and sending data from that change stream to Kafka Connect. Your source
+A {+source-connector+} works by opening a single change stream with
+MongoDB and sending data from that change stream to {+kc+}. Your source
 connector maintains its change stream for the duration of its runtime, and your
 connector closes its change stream when you stop it.

--- a/source/includes/source-connector-change-stream.rst
+++ b/source/includes/source-connector-change-stream.rst
@@ -1,0 +1,4 @@
+A {+mkc+} source connector works by opening a single change stream with
+MongoDB and sending data from that change stream to Kafka Connect. Your source
+connector maintains its change stream for the duration of its runtime, and your
+connector closes its change stream when you stop it.

--- a/source/source-connector.txt
+++ b/source/source-connector.txt
@@ -27,6 +27,8 @@ This section focuses on the **{+source-connector+}**.
 The {+source-connector+} is a {+kc+} connector that reads data from MongoDB and 
 writes data to {+ak+}.
 
+.. include:: /includes/source-connector-change-stream.rst
+
 Configuration Properties
 ------------------------
 

--- a/source/source-connector/fundamentals/change-streams.txt
+++ b/source/source-connector/fundamentals/change-streams.txt
@@ -97,10 +97,7 @@ learn how to set your WiredTiger cache, see the guide on the
 Source Connectors
 -----------------
 
-A {+mkc+} source connector works by opening a single change stream with
-MongoDB and sending data from that change stream to Kafka Connect. Your source
-connector maintains its change stream for the duration of its runtime, and your
-connector closes its change stream when you stop it.
+.. include:: /includes/source-connector-change-stream.rst
 
 To view the available options to configure your source connector's change stream,
 see the :ref:`<source-configuration-change-stream>` page.


### PR DESCRIPTION
# Pull Request Info

I didn't believe that the CDC handler data in the initial ticket should be applied to the top level Sink connector page as AFAICT you do not need to apply a CDC handler to a connector, it is an [optional](https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-22974/tutorials/sink-connector/#configure-the-sink-connector) configuration. Let me know if you disagree!

Duplicate important info on how sink/source connector work from fundamentals pages to top level pages.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

[JIRA](https://jira.mongodb.org/browse/DOCSP-22974)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-22974/source-connector/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
