### PR TITLE
DOCSP-26355: startup mode

### DIFF
--- a/source/includes/usage-examples/copy/source.properties
+++ b/source/includes/usage-examples/copy/source.properties
@@ -2,5 +2,5 @@ connector.class=com.mongodb.kafka.connect.MongoSourceConnector
 connection.uri=<your production MongoDB connection uri>
 database=shopping
 collection=customers
-copy.existing=true
-copy.existing.pipeline=[{ "$match": { "country": "Mexico" } }]
+startup.mode=copy_existing
+startup.mode.copy.existing.pipeline=[{ "$match": { "country": "Mexico" } }]

--- a/source/source-connector/configuration-properties.txt
+++ b/source/source-connector/configuration-properties.txt
@@ -68,7 +68,7 @@ for more information on these settings.
    Kafka Topic </source-connector/configuration-properties/kafka-topic>
    Change Stream </source-connector/configuration-properties/change-stream>
    Output Format </source-connector/configuration-properties/output-format>
-   Startup </source-connector/configuration-properties/copy-existing>
+   Startup </source-connector/configuration-properties/startup>
    Error Handling and Resuming from Interruption </source-connector/configuration-properties/error-handling>
    All Properties </source-connector/configuration-properties/all-properties>
 

--- a/source/source-connector/configuration-properties.txt
+++ b/source/source-connector/configuration-properties.txt
@@ -68,7 +68,7 @@ for more information on these settings.
    Kafka Topic </source-connector/configuration-properties/kafka-topic>
    Change Stream </source-connector/configuration-properties/change-stream>
    Output Format </source-connector/configuration-properties/output-format>
-   Startup Mode </source-connector/configuration-properties/copy-existing>
+   Startup </source-connector/configuration-properties/copy-existing>
    Error Handling and Resuming from Interruption </source-connector/configuration-properties/error-handling>
    All Properties </source-connector/configuration-properties/all-properties>
 

--- a/source/source-connector/configuration-properties.txt
+++ b/source/source-connector/configuration-properties.txt
@@ -47,7 +47,7 @@ See the following categories for a list of related configuration properties:
      - Specify the format of the data the connector publishes to your
        Kafka topic.
 
-   * - :ref:`Copy Existing Properties <source-configuration-copy-existing>`
+   * - :ref:`Startup Properties <source-configuration-startup>`
      - Specify what data the connector should convert to Change Stream
        events.
 
@@ -68,7 +68,7 @@ for more information on these settings.
    Kafka Topic </source-connector/configuration-properties/kafka-topic>
    Change Stream </source-connector/configuration-properties/change-stream>
    Output Format </source-connector/configuration-properties/output-format>
-   Copy Existing </source-connector/configuration-properties/copy-existing>
+   Startup Mode </source-connector/configuration-properties/startup-properties>
    Error Handling and Resuming from Interruption </source-connector/configuration-properties/error-handling>
    All Properties </source-connector/configuration-properties/all-properties>
 

--- a/source/source-connector/configuration-properties.txt
+++ b/source/source-connector/configuration-properties.txt
@@ -68,7 +68,7 @@ for more information on these settings.
    Kafka Topic </source-connector/configuration-properties/kafka-topic>
    Change Stream </source-connector/configuration-properties/change-stream>
    Output Format </source-connector/configuration-properties/output-format>
-   Startup Mode </source-connector/configuration-properties/startup-properties>
+   Startup Mode </source-connector/configuration-properties/copy-existing>
    Error Handling and Resuming from Interruption </source-connector/configuration-properties/error-handling>
    All Properties </source-connector/configuration-properties/all-properties>
 

--- a/source/source-connector/configuration-properties/all-properties.txt
+++ b/source/source-connector/configuration-properties/all-properties.txt
@@ -81,14 +81,14 @@ To view only the options related to the format of your output, see the
 Startup Mode
 ------------
 
-.. include:: /source-connector/configuration-properties/startup-properties.txt
+.. include:: /source-connector/configuration-properties/copy-existing.txt
    :start-after: source-configuration-startup-description-start
    :end-before: source-configuration-startup-description-end
 
 To view only the options related to startup modes, see the
 :ref:`<source-configuration-startup>` page.
 
-.. include:: /source-connector/configuration-properties/startup-properties.txt
+.. include:: /source-connector/configuration-properties/copy-existing.txt
    :start-after: source-configuration-startup-table-start
    :end-before: source-configuration-startup-table-end
 

--- a/source/source-connector/configuration-properties/all-properties.txt
+++ b/source/source-connector/configuration-properties/all-properties.txt
@@ -78,14 +78,14 @@ To view only the options related to the format of your output, see the
    :start-after: source-configuration-output-format-table-start
    :end-before: source-configuration-output-format-table-end
 
-Startup Mode
-------------
+Startup
+-------
 
 .. include:: /source-connector/configuration-properties/copy-existing.txt
    :start-after: source-configuration-startup-description-start
    :end-before: source-configuration-startup-description-end
 
-To view only the options related to startup modes, see the
+To view only the options related to startup, see the
 :ref:`<source-configuration-startup>` page.
 
 .. include:: /source-connector/configuration-properties/copy-existing.txt

--- a/source/source-connector/configuration-properties/all-properties.txt
+++ b/source/source-connector/configuration-properties/all-properties.txt
@@ -81,14 +81,14 @@ To view only the options related to the format of your output, see the
 Startup
 -------
 
-.. include:: /source-connector/configuration-properties/copy-existing.txt
+.. include:: /source-connector/configuration-properties/startup.txt
    :start-after: source-configuration-startup-description-start
    :end-before: source-configuration-startup-description-end
 
 To view only the options related to startup, see the
 :ref:`<source-configuration-startup>` page.
 
-.. include:: /source-connector/configuration-properties/copy-existing.txt
+.. include:: /source-connector/configuration-properties/startup.txt
    :start-after: source-configuration-startup-table-start
    :end-before: source-configuration-startup-table-end
 

--- a/source/source-connector/configuration-properties/all-properties.txt
+++ b/source/source-connector/configuration-properties/all-properties.txt
@@ -78,19 +78,19 @@ To view only the options related to the format of your output, see the
    :start-after: source-configuration-output-format-table-start
    :end-before: source-configuration-output-format-table-end
 
-Copy Existing
--------------
+Startup Mode
+------------
 
-.. include:: /source-connector/configuration-properties/copy-existing.txt
-   :start-after: source-configuration-copy-existing-description-start
-   :end-before: source-configuration-copy-existing-description-end
+.. include:: /source-connector/configuration-properties/startup-properties.txt
+   :start-after: source-configuration-startup-description-start
+   :end-before: source-configuration-startup-description-end
 
-To view only the options related to copying data, see the
-:ref:`<source-configuration-copy-existing>` page.
+To view only the options related to startup modes, see the
+:ref:`<source-configuration-startup>` page.
 
-.. include:: /source-connector/configuration-properties/copy-existing.txt
-   :start-after: source-configuration-copy-existing-table-start
-   :end-before: source-configuration-copy-existing-table-end
+.. include:: /source-connector/configuration-properties/startup-properties.txt
+   :start-after: source-configuration-startup-table-start
+   :end-before: source-configuration-startup-table-end
 
 Error Handling and Resuming from Interruption
 ---------------------------------------------

--- a/source/source-connector/configuration-properties/copy-existing.txt
+++ b/source/source-connector/configuration-properties/copy-existing.txt
@@ -1,9 +1,8 @@
-.. _source-configuration-startup:
 .. _source-configuration-copy-existing:
 
-==================
-Startup Properties
-==================
+========================
+Copy Existing Properties
+========================
 
 .. default-domain:: mongodb
 
@@ -16,25 +15,24 @@ Startup Properties
 Overview
 --------
 
-.. _source-configuration-startup-description-start:
 .. _source-configuration-copy-existing-description-start:
-
-Use the following configuration settings to configure startup of the
-source connector to convert MongoDB collections into Change Stream
-events.
-
-.. _source-configuration-startup-description-end:
-.. _source-configuration-copy-existing-description-end:
 
 .. important:: ``copy.existing*`` Properties are Deprecated
 
    Starting in Version 1.9 of the {+mkc+}, ``copy.existing*`` properties
-   are deprecated. You should use ``startup.mode*`` properties to
-   configure the copy existing feature.
+   are deprecated and may be removed in a future release. You should use
+   ``startup.mode*`` properties to configure the copy existing feature.
+   To learn more about ``startup.mode*`` settings, see
+   :ref:`source-configuration-startup`.
 
-.. tip::
+Use the following configuration settings to enable the copy existing
+feature which converts MongoDB collections into Change Stream events.
 
-   For an example using the copy existing feature, see the
+.. _source-configuration-copy-existing-description-end:
+
+.. seealso::
+
+   For an example of the copy existing feature, see the
    :ref:`<source-usage-example-copy-existing-data>` Usage Example.
 
 .. include:: /includes/source-config-link.rst
@@ -42,57 +40,32 @@ events.
 Settings
 --------
 
-.. _source-configuration-startup-table-start:
 .. _source-configuration-copy-existing-table-start:
 
 .. list-table::
    :header-rows: 1
-   :widths: 40 60
+   :widths: 35 65
 
    * - Name
      - Description
 
-   * - | **startup.mode**
-     - | **Type:** string
+   * - | **copy.existing**
+     - | **Type:** boolean
        |
        | **Description:**
-       | Specifies how the connector should start up when there is no
-         source offset available. Resuming a change stream requires a
-         resume token, which the connector gets from the source offset.
-         If no source offset is available, the connector may either
-         ignore all or some of the existing source data, or may at first
-         copy all existing source data and then continue with processing
-         new data.
-       |
-       | If ``startup.mode=latest``, the connector ignores all existing
-         source data. If ``startup.mode=timestamp``, the connector
-         actuates ``startup.mode.timestamp.*`` properties. If no
-         properties are configured, ``timestamp`` is equivalent to
-         ``latest``. If ``startup.mode=copy_existing``, the connector
-         copies all existing source data to Change Stream events.
+       | Whether to enable the copy existing feature which converts all
+         data in a MongoDB collection to Change Stream events and
+         publishes them on Kafka topics. If MongoDB changes the source
+         collection data after the connector starts the copy process, the
+         connector creates events for the changes after it completes the copy
+         process.
 
        .. include:: /includes/copy-existing-admonition.rst
 
-       | **Default**:``latest``
-       | **Accepted Values**: ``latest``, ``timestamp``, ``copy_existing``
-       
-   * - | **startup.mode.timestamp.start.at.operation.time**
-     - | **Type:** string
-       |
-       | **Description:**
-       | Actuated only if ``startup.mode=timestamp``. Specifies the
-         starting point for the change stream. To learn more about
-         Change Stream parameters, see the :rapid:`Server manual entry </reference/operator/aggregation/changeStream/>`.
-       | **Default**: ``""``
-       | **Accepted Values**:
-       | - An integer number of seconds since the
-           Epoch in decimal format (for example, ``30``)
-       | - An instant in the ISO-8601 format with one second precision (for example,
-           ``1970-01-01T00:00:30Z``)
-       | - A BSON Timestamp in the canonical extended JSON (v2) format
-           (for example, ``{"$timestamp": {"t": 30, "i": 0}}``)
+       | **Default**:``false``
+       | **Accepted Values**: ``true`` or ``false``
 
-   * - | **startup.mode.copy.existing.namespace.regex**
+   * - | **copy.existing.namespace.regex**
      - | **Type:** string
        |
        | **Description:**
@@ -108,7 +81,7 @@ Settings
 
           .. code-block:: none
 
-             startup.mode.copy.existing.namespace.regex=stats\\.page.*
+             copy.existing.namespace.regex=stats\.page.*
 
           The "\\" character in the example above escapes the "." character
           that follows it in the regular expression. For more information on
@@ -118,11 +91,11 @@ Settings
        | **Default**: ``""``
        | **Accepted Values**: A valid regular expression
 
-   * - | **startup.mode.copy.existing.pipeline**
+   * - | **copy.existing.pipeline**
      - | **Type:** string
        |
        | **Description:**
-       | An inline array of :manual:`pipeline operations </core/aggregation-pipeline/>`
+       | An array of :manual:`pipeline operations </core/aggregation-pipeline/>`
          the connector runs when copying existing data. You can use this
          setting to filter the source collection and improve the use of
          indexes in the copying process.
@@ -135,12 +108,12 @@ Settings
 
           .. code-block:: none
 
-             startup.mode.copy.existing.pipeline=[ { "$match": { "closed": "false" } } ]
+             copy.existing.pipeline=[ { "$match": { "closed": "false" } } ]
 
-       | **Default**: ``""``
+       | **Default**: ``[]``
        | **Accepted Values**: Valid aggregation pipeline stages
 
-   * - | **startup.mode.copy.existing.max.threads**
+   * - | **copy.existing.max.threads**
      - | **Type:** int
        |
        | **Description:**
@@ -148,7 +121,7 @@ Settings
        | **Default**: number of processors available in the environment
        | **Accepted Values**: An integer
 
-   * - | **startup.mode.copy.existing.queue.size**
+   * - | **copy.existing.queue.size**
      - | **Type:** int
        |
        | **Description:**
@@ -156,7 +129,7 @@ Settings
        | **Default**: ``16000``
        | **Accepted Values**: An integer
 
-   * - | **startup.mode.copy.existing.allow.disk.use**
+   * - | **copy.existing.allow.disk.use**
      - | **Type:** boolean
        |
        | **Description:**
@@ -164,7 +137,5 @@ Settings
          the connector sets the copy existing aggregation 
          to use temporary disk storage. 
        | **Default**: ``true``
-       | **Accepted Values**: ``true`` or ``false``
 
-.. _source-configuration-startup-table-end:
 .. _source-configuration-copy-existing-table-end:

--- a/source/source-connector/configuration-properties/copy-existing.txt
+++ b/source/source-connector/configuration-properties/copy-existing.txt
@@ -22,7 +22,7 @@ Overview
    Starting in Version 1.9 of the {+mkc+}, ``copy.existing*`` properties
    are deprecated and may be removed in a future release. You should use
    ``startup.mode*`` properties to configure the copy existing feature.
-   To learn more about ``startup.mode*`` settings, see
+   To learn about ``startup.mode*`` settings, see
    :ref:`source-configuration-startup`.
 
 Use the following configuration settings to enable the copy existing

--- a/source/source-connector/configuration-properties/copy-existing.txt
+++ b/source/source-connector/configuration-properties/copy-existing.txt
@@ -29,7 +29,7 @@ events.
 .. important:: ``copy.existing*`` Properties are Deprecated
 
    Starting in Version 1.9 of the {+mkc+}, ``copy.existing*`` properties
-   are deprecated. You should use ``startup.mode*`` properties to configure
+   are deprecated. You should use ``startup.mode*`` properties to
    configure the copy existing feature.
 
 .. tip::
@@ -47,7 +47,7 @@ Settings
 
 .. list-table::
    :header-rows: 1
-   :widths: 35 65
+   :widths: 40 60
 
    * - Name
      - Description
@@ -63,6 +63,7 @@ Settings
          ignore all or some of the existing source data, or may at first
          copy all existing source data and then continue with processing
          new data.
+       |
        | If ``startup.mode=latest``, the connector ignores all existing
          source data. If ``startup.mode=timestamp``, the connector
          actuates ``startup.mode.timestamp.*`` properties. If no
@@ -81,7 +82,7 @@ Settings
        | **Description:**
        | Actuated only if ``startup.mode=timestamp``. Specifies the
          starting point for the change stream. To learn more about
-         Change Stream parameters, see the :rapid:`Server manual entry </rapid/reference/operator/aggregation/changeStream/>`.
+         Change Stream parameters, see the :rapid:`Server manual entry </reference/operator/aggregation/changeStream/>`.
        | **Default**: ``""``
        | **Accepted Values**:
        | - An integer number of seconds since the

--- a/source/source-connector/configuration-properties/copy-existing.txt
+++ b/source/source-connector/configuration-properties/copy-existing.txt
@@ -71,19 +71,18 @@ Settings
        | **Description:**
        | Regular expression the connector uses to match namespaces from
          which to copy data. A namespace describes the MongoDB database name
-         and collection separated by a period, e.g.
-         ``databaseName.collectionName``.
+         and collection separated by a period (for example, ``databaseName.collectionName``).
 
        .. example::
 
-          In the following example, the regular expression setting matches
-          collections that start with "page" in the "stats" database.
+          In the following example, the regular-expression setting matches
+          collections that start with "page" in the ``stats`` database.
 
           .. code-block:: none
 
              copy.existing.namespace.regex=stats\.page.*
 
-          The "\\" character in the example above escapes the "." character
+          The "\" character in the example above escapes the "." character
           that follows it in the regular expression. For more information on
           how to build regular expressions, see the Java API documentation on
           `Patterns <https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html>`__.
@@ -133,9 +132,8 @@ Settings
      - | **Type:** boolean
        |
        | **Description:**
-       | When set to ``true``, 
-         the connector sets the copy existing aggregation 
-         to use temporary disk storage. 
+       | When set to ``true``, the connector uses temporary disk storage
+         for the copy existing aggregation. 
        | **Default**: ``true``
 
 .. _source-configuration-copy-existing-table-end:

--- a/source/source-connector/configuration-properties/copy-existing.txt
+++ b/source/source-connector/configuration-properties/copy-existing.txt
@@ -1,4 +1,5 @@
 .. _source-configuration-startup:
+.. _source-configuration-copy-existing:
 
 ==================
 Startup Properties
@@ -16,11 +17,13 @@ Overview
 --------
 
 .. _source-configuration-startup-description-start:
+.. _source-configuration-copy-existing-description-start:
 
 This guide describes the settings you can use to configure the startup
 mode which converts MongoDB collections into Change Stream events.
 
 .. _source-configuration-startup-description-end:
+.. _source-configuration-copy-existing-description-end:
 
 .. important:: ``copy.existing*`` Properties are Deprecated
 
@@ -39,6 +42,7 @@ Settings
 --------
 
 .. _source-configuration-startup-table-start:
+.. _source-configuration-copy-existing-table-start:
 
 .. list-table::
    :header-rows: 1
@@ -153,3 +157,4 @@ Settings
        | **Accepted Values**: ``true`` or ``false``
 
 .. _source-configuration-startup-table-end:
+.. _source-configuration-copy-existing-table-end:

--- a/source/source-connector/configuration-properties/copy-existing.txt
+++ b/source/source-connector/configuration-properties/copy-existing.txt
@@ -19,8 +19,9 @@ Overview
 .. _source-configuration-startup-description-start:
 .. _source-configuration-copy-existing-description-start:
 
-This guide describes the settings you can use to configure the startup
-mode which converts MongoDB collections into Change Stream events.
+Use the following configuration settings to configure startup of the
+source connector to convert MongoDB collections into Change Stream
+events.
 
 .. _source-configuration-startup-description-end:
 .. _source-configuration-copy-existing-description-end:
@@ -28,12 +29,12 @@ mode which converts MongoDB collections into Change Stream events.
 .. important:: ``copy.existing*`` Properties are Deprecated
 
    Starting in Version 1.9 of the {+mkc+}, ``copy.existing*`` properties
-   are deprecated. You must use ``startup.mode*`` properties to configure
-   the startup feature, previously known as the copy existing feature.
+   are deprecated. You should use ``startup.mode*`` properties to configure
+   configure the copy existing feature.
 
 .. tip::
 
-   For an example enabling a startup mode, see the
+   For an example using the copy existing feature, see the
    :ref:`<source-usage-example-copy-existing-data>` Usage Example.
 
 .. include:: /includes/source-config-link.rst
@@ -51,38 +52,46 @@ Settings
    * - Name
      - Description
 
-   * - | ``startup.mode``
+   * - | **startup.mode**
      - | **Type:** string
        |
        | **Description:**
-       | Whether to enable the startup feature which converts all
-         data in a MongoDB collection to Change Stream events and
-         publishes them on Kafka topics. If MongoDB changes the source
-         collection data after the connector starts the copy process, the
-         connector creates events for the changes after it completes the copy
-         process.
+       | Specifies how the connector should start up when there is no
+         source offset available. Resuming a change stream requires a
+         resume token, which the connector gets from the source offset.
+         If no source offset is available, the connector may either
+         ignore all or some of the existing source data, or may at first
+         copy all existing source data and then continue with processing
+         new data.
+       | If ``startup.mode=latest``, the connector ignores all existing
+         source data. If ``startup.mode=timestamp``, the connector
+         actuates ``startup.mode.timestamp.*`` properties. If no
+         properties are configured, ``timestamp`` is equivalent to
+         ``latest``. If ``startup.mode=copy_existing``, the connector
+         copies all existing source data to Change Stream events.
 
        .. include:: /includes/copy-existing-admonition.rst
 
        | **Default**:``latest``
        | **Accepted Values**: ``latest``, ``timestamp``, ``copy_existing``
        
-   * - | ``startup.mode.timestamp.start.at.operation.time``
+   * - | **startup.mode.timestamp.start.at.operation.time**
      - | **Type:** string
        |
        | **Description:**
        | Actuated only if ``startup.mode=timestamp``. Specifies the
-         starting point for the change stream.
+         starting point for the change stream. To learn more about
+         Change Stream parameters, see the :rapid:`Server manual entry </rapid/reference/operator/aggregation/changeStream/>`.
        | **Default**: ``""``
        | **Accepted Values**:
        | - An integer number of seconds since the
-           Epoch in decimal format (for example, 30)
+           Epoch in decimal format (for example, ``30``)
        | - An instant in the ISO-8601 format with one second precision (for example,
-           1970-01-01T00:00:30Z)
+           ``1970-01-01T00:00:30Z``)
        | - A BSON Timestamp in the canonical extended JSON (v2) format
-           (for example, {\"$timestamp\": {\"t\": 30, \"i\": 0}})
+           (for example, ``{"$timestamp": {"t": 30, "i": 0}}``)
 
-   * - | ``startup.mode.copy.existing.namespace.regex``
+   * - | **startup.mode.copy.existing.namespace.regex**
      - | **Type:** string
        |
        | **Description:**
@@ -108,7 +117,7 @@ Settings
        | **Default**: ``""``
        | **Accepted Values**: A valid regular expression
 
-   * - | ``startup.mode.copy.existing.pipeline``
+   * - | **startup.mode.copy.existing.pipeline**
      - | **Type:** string
        |
        | **Description:**
@@ -125,12 +134,12 @@ Settings
 
           .. code-block:: none
 
-             startup.mode.copy.existing.pipeline=[{\"$match\": {\"closed\": \"false\"}}]
+             startup.mode.copy.existing.pipeline=[ { "$match": { "closed": "false" } } ]
 
        | **Default**: ``""``
        | **Accepted Values**: Valid aggregation pipeline stages
 
-   * - | ``startup.mode.copy.existing.max.threads``
+   * - | **startup.mode.copy.existing.max.threads**
      - | **Type:** int
        |
        | **Description:**
@@ -138,7 +147,7 @@ Settings
        | **Default**: number of processors available in the environment
        | **Accepted Values**: An integer
 
-   * - | ``startup.mode.copy.existing.queue.size``
+   * - | **startup.mode.copy.existing.queue.size**
      - | **Type:** int
        |
        | **Description:**
@@ -146,7 +155,7 @@ Settings
        | **Default**: ``16000``
        | **Accepted Values**: An integer
 
-   * - | ``startup.mode.copy.existing.allow.disk.use``
+   * - | **startup.mode.copy.existing.allow.disk.use**
      - | **Type:** boolean
        |
        | **Description:**

--- a/source/source-connector/configuration-properties/startup-properties.txt
+++ b/source/source-connector/configuration-properties/startup-properties.txt
@@ -17,7 +17,7 @@ Overview
 
 .. _source-configuration-startup-description-start:
 
-This guide describes the configuration settings you can use to configure the startup
+This guide describes the settings you can use to configure the startup
 mode which converts MongoDB collections into Change Stream events.
 
 .. _source-configuration-startup-description-end:
@@ -67,16 +67,16 @@ Settings
      - | **Type:** string
        |
        | **Description:**
-       | Actuated only if ``startup.mode = timestamp``. Specifies the
+       | Actuated only if ``startup.mode=timestamp``. Specifies the
          starting point for the change stream.
        | **Default**: ``""``
        | **Accepted Values**:
-         - An integer number of seconds since the
-           Epoch in decimal format (for example, "30")
-         - An instant in the ISO-8601 format with one second precision (for example,
-           "1970-01-01T00:00:30Z")
-         - A BSON Timestamp in the canonical extended JSON (v2) format
-           (for example, "{\"$timestamp\": {\"t\": 30, \"i\": 0}}")
+       | - An integer number of seconds since the
+           Epoch in decimal format (for example, 30)
+       | - An instant in the ISO-8601 format with one second precision (for example,
+           1970-01-01T00:00:30Z)
+       | - A BSON Timestamp in the canonical extended JSON (v2) format
+           (for example, {\"$timestamp\": {\"t\": 30, \"i\": 0}})
 
    * - | ``startup.mode.copy.existing.namespace.regex``
      - | **Type:** string

--- a/source/source-connector/configuration-properties/startup-properties.txt
+++ b/source/source-connector/configuration-properties/startup-properties.txt
@@ -1,8 +1,8 @@
-.. _source-configuration-copy-existing:
+.. _source-configuration-startup:
 
-========================
-Copy Existing Properties
-========================
+==================
+Startup Properties
+==================
 
 .. default-domain:: mongodb
 
@@ -15,16 +15,22 @@ Copy Existing Properties
 Overview
 --------
 
-.. _source-configuration-copy-existing-description-start:
+.. _source-configuration-startup-description-start:
 
-Use the following configuration settings to enable the copy existing
-feature which converts MongoDB collections into Change Stream events.
+This guide describes the configuration settings you can use to configure the startup
+mode which converts MongoDB collections into Change Stream events.
 
-.. _source-configuration-copy-existing-description-end:
+.. _source-configuration-startup-description-end:
 
-.. seealso::
+.. important:: ``copy.existing*`` Properties are Deprecated
 
-   For an example of the copy existing feature, see the
+   Starting in Version 1.9 of the {+mkc+}, ``copy.existing*`` properties
+   are deprecated. You must use ``startup.mode*`` properties to configure
+   the startup feature, previously known as the copy existing feature.
+
+.. tip::
+
+   For an example enabling a startup mode, see the
    :ref:`<source-usage-example-copy-existing-data>` Usage Example.
 
 .. include:: /includes/source-config-link.rst
@@ -32,7 +38,7 @@ feature which converts MongoDB collections into Change Stream events.
 Settings
 --------
 
-.. _source-configuration-copy-existing-table-start:
+.. _source-configuration-startup-table-start:
 
 .. list-table::
    :header-rows: 1
@@ -41,11 +47,11 @@ Settings
    * - Name
      - Description
 
-   * - | **copy.existing**
-     - | **Type:** boolean
+   * - | ``startup.mode``
+     - | **Type:** string
        |
        | **Description:**
-       | Whether to enable the copy existing feature which converts all
+       | Whether to enable the startup feature which converts all
          data in a MongoDB collection to Change Stream events and
          publishes them on Kafka topics. If MongoDB changes the source
          collection data after the connector starts the copy process, the
@@ -54,10 +60,25 @@ Settings
 
        .. include:: /includes/copy-existing-admonition.rst
 
-       | **Default**:``false``
-       | **Accepted Values**: ``true`` or ``false``
+       | **Default**:``latest``
+       | **Accepted Values**: ``latest``, ``timestamp``, ``copy_existing``
+       
+   * - | ``startup.mode.timestamp.start.at.operation.time``
+     - | **Type:** string
+       |
+       | **Description:**
+       | Actuated only if ``startup.mode = timestamp``. Specifies the
+         starting point for the change stream.
+       | **Default**: ``""``
+       | **Accepted Values**:
+         - An integer number of seconds since the
+           Epoch in decimal format (for example, "30")
+         - An instant in the ISO-8601 format with one second precision (for example,
+           "1970-01-01T00:00:30Z")
+         - A BSON Timestamp in the canonical extended JSON (v2) format
+           (for example, "{\"$timestamp\": {\"t\": 30, \"i\": 0}}")
 
-   * - | **copy.existing.namespace.regex**
+   * - | ``startup.mode.copy.existing.namespace.regex``
      - | **Type:** string
        |
        | **Description:**
@@ -73,7 +94,7 @@ Settings
 
           .. code-block:: none
 
-             copy.existing.namespace.regex=stats\.page.*
+             startup.mode.copy.existing.namespace.regex=stats\\.page.*
 
           The "\\" character in the example above escapes the "." character
           that follows it in the regular expression. For more information on
@@ -83,11 +104,11 @@ Settings
        | **Default**: ``""``
        | **Accepted Values**: A valid regular expression
 
-   * - | **copy.existing.pipeline**
+   * - | ``startup.mode.copy.existing.pipeline``
      - | **Type:** string
        |
        | **Description:**
-       | An array of :manual:`pipeline operations </core/aggregation-pipeline/>`
+       | An inline array of :manual:`pipeline operations </core/aggregation-pipeline/>`
          the connector runs when copying existing data. You can use this
          setting to filter the source collection and improve the use of
          indexes in the copying process.
@@ -100,12 +121,12 @@ Settings
 
           .. code-block:: none
 
-             copy.existing.pipeline=[ { "$match": { "closed": "false" } } ]
+             startup.mode.copy.existing.pipeline=[{\"$match\": {\"closed\": \"false\"}}]
 
-       | **Default**: ``[]``
+       | **Default**: ``""``
        | **Accepted Values**: Valid aggregation pipeline stages
 
-   * - | **copy.existing.max.threads**
+   * - | ``startup.mode.copy.existing.max.threads``
      - | **Type:** int
        |
        | **Description:**
@@ -113,7 +134,7 @@ Settings
        | **Default**: number of processors available in the environment
        | **Accepted Values**: An integer
 
-   * - | **copy.existing.queue.size**
+   * - | ``startup.mode.copy.existing.queue.size``
      - | **Type:** int
        |
        | **Description:**
@@ -121,7 +142,7 @@ Settings
        | **Default**: ``16000``
        | **Accepted Values**: An integer
 
-   * - | **copy.existing.allow.disk.use**
+   * - | ``startup.mode.copy.existing.allow.disk.use``
      - | **Type:** boolean
        |
        | **Description:**
@@ -129,5 +150,6 @@ Settings
          the connector sets the copy existing aggregation 
          to use temporary disk storage. 
        | **Default**: ``true``
+       | **Accepted Values**: ``true`` or ``false``
 
-.. _source-configuration-copy-existing-table-end:
+.. _source-configuration-startup-table-end:

--- a/source/source-connector/configuration-properties/startup.txt
+++ b/source/source-connector/configuration-properties/startup.txt
@@ -56,12 +56,15 @@ Settings
        |
        | If ``startup.mode=latest``, the connector ignores all existing
          source data.
+       |
        | If ``startup.mode=timestamp``, the connector
          actuates ``startup.mode.timestamp.*`` properties. If no
          properties are configured, ``timestamp`` is equivalent to
          ``latest``.
+       |
        | If ``startup.mode=copy_existing``, the connector
-         copies all existing source data to Change Stream events.
+         copies all existing source data to Change Stream events. This
+         setting is equivalent to the deprecated setting ``copy.existing=true``.
 
        .. include:: /includes/copy-existing-admonition.rst
 
@@ -77,11 +80,11 @@ Settings
          Change Stream parameters, see the :rapid:`Server manual entry </reference/operator/aggregation/changeStream/>`.
        | **Default**: ``""``
        | **Accepted Values**:
-       | - An integer number of seconds since the
+       | * An integer number of seconds since the
            Epoch in decimal format (for example, ``30``)
-       | - An instant in the ISO-8601 format with one second precision (for example,
+       | * An instant in the ISO-8601 format with one second precision (for example,
            ``1970-01-01T00:00:30Z``)
-       | - A BSON Timestamp in the canonical extended JSON (v2) format
+       | * A BSON Timestamp in the canonical extended JSON (v2) format
            (for example, ``{"$timestamp": {"t": 30, "i": 0}}``)
 
    * - | **startup.mode.copy.existing.namespace.regex**

--- a/source/source-connector/configuration-properties/startup.txt
+++ b/source/source-connector/configuration-properties/startup.txt
@@ -1,0 +1,161 @@
+.. _source-configuration-startup:
+
+==================
+Startup Properties
+==================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+.. _source-configuration-startup-description-start:
+
+Use the following configuration settings to configure startup of the
+source connector to convert MongoDB collections into Change Stream
+events.
+
+.. _source-configuration-startup-description-end:
+
+.. tip::
+
+   For an example using the copy existing feature, see the
+   :ref:`<source-usage-example-copy-existing-data>` Usage Example.
+
+.. include:: /includes/source-config-link.rst
+
+Settings
+--------
+
+.. _source-configuration-startup-table-start:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Name
+     - Description
+
+   * - | **startup.mode**
+     - | **Type:** string
+       |
+       | **Description:**
+       | Specifies how the connector should start up when there is no
+         source offset available. Resuming a change stream requires a
+         resume token, which the connector gets from the source offset.
+         If no source offset is available, the connector may either
+         ignore all or some of the existing source data, or may at first
+         copy all existing source data and then continue with processing
+         new data.
+       |
+       | If ``startup.mode=latest``, the connector ignores all existing
+         source data.
+       | If ``startup.mode=timestamp``, the connector
+         actuates ``startup.mode.timestamp.*`` properties. If no
+         properties are configured, ``timestamp`` is equivalent to
+         ``latest``.
+       | If ``startup.mode=copy_existing``, the connector
+         copies all existing source data to Change Stream events.
+
+       .. include:: /includes/copy-existing-admonition.rst
+
+       | **Default**:``latest``
+       | **Accepted Values**: ``latest``, ``timestamp``, ``copy_existing``
+       
+   * - | **startup.mode.timestamp.start.at.operation.time**
+     - | **Type:** string
+       |
+       | **Description:**
+       | Actuated only if ``startup.mode=timestamp``. Specifies the
+         starting point for the change stream. To learn more about
+         Change Stream parameters, see the :rapid:`Server manual entry </reference/operator/aggregation/changeStream/>`.
+       | **Default**: ``""``
+       | **Accepted Values**:
+       | - An integer number of seconds since the
+           Epoch in decimal format (for example, ``30``)
+       | - An instant in the ISO-8601 format with one second precision (for example,
+           ``1970-01-01T00:00:30Z``)
+       | - A BSON Timestamp in the canonical extended JSON (v2) format
+           (for example, ``{"$timestamp": {"t": 30, "i": 0}}``)
+
+   * - | **startup.mode.copy.existing.namespace.regex**
+     - | **Type:** string
+       |
+       | **Description:**
+       | Regular expression the connector uses to match namespaces from
+         which to copy data. A namespace describes the MongoDB database name
+         and collection separated by a period, e.g.
+         ``databaseName.collectionName``.
+
+       .. example::
+
+          In the following example, the regular expression setting matches
+          collections that start with "page" in the "stats" database.
+
+          .. code-block:: none
+
+             startup.mode.copy.existing.namespace.regex=stats\.page.*
+
+          The "\\" character in the example above escapes the "." character
+          that follows it in the regular expression. For more information on
+          how to build regular expressions, see the Java API documentation on
+          `Patterns <https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html>`__.
+
+       | **Default**: ``""``
+       | **Accepted Values**: A valid regular expression
+
+   * - | **startup.mode.copy.existing.pipeline**
+     - | **Type:** string
+       |
+       | **Description:**
+       | An inline array of :manual:`pipeline operations </core/aggregation-pipeline/>`
+         the connector runs when copying existing data. You can use this
+         setting to filter the source collection and improve the use of
+         indexes in the copying process.
+
+       .. example::
+
+          The following example shows how you can use the :manual:`$match </reference/operator/aggregation/match/>`
+          aggregation operator to instruct the connector to copy only
+          documents that contain a ``closed`` field with a value of ``false``.
+
+          .. code-block:: none
+
+             startup.mode.copy.existing.pipeline=[ { "$match": { "closed": "false" } } ]
+
+       | **Default**: ``""``
+       | **Accepted Values**: Valid aggregation pipeline stages
+
+   * - | **startup.mode.copy.existing.max.threads**
+     - | **Type:** int
+       |
+       | **Description:**
+       | The maximum number of threads the connector can use to copy data.
+       | **Default**: number of processors available in the environment
+       | **Accepted Values**: An integer
+
+   * - | **startup.mode.copy.existing.queue.size**
+     - | **Type:** int
+       |
+       | **Description:**
+       | The size of the queue the connector can use when copying data.
+       | **Default**: ``16000``
+       | **Accepted Values**: An integer
+
+   * - | **startup.mode.copy.existing.allow.disk.use**
+     - | **Type:** boolean
+       |
+       | **Description:**
+       | When set to ``true``, 
+         the connector sets the copy existing aggregation 
+         to use temporary disk storage. 
+       | **Default**: ``true``
+       | **Accepted Values**: ``true`` or ``false``
+
+.. _source-configuration-startup-table-end:

--- a/source/source-connector/configuration-properties/startup.txt
+++ b/source/source-connector/configuration-properties/startup.txt
@@ -93,19 +93,18 @@ Settings
        | **Description:**
        | Regular expression the connector uses to match namespaces from
          which to copy data. A namespace describes the MongoDB database name
-         and collection separated by a period, e.g.
-         ``databaseName.collectionName``.
+         and collection separated by a period (for example, ``databaseName.collectionName``).
 
        .. example::
 
-          In the following example, the regular expression setting matches
-          collections that start with "page" in the "stats" database.
+          In the following example, the regular-expression setting matches
+          collections that start with "page" in the ``stats`` database.
 
           .. code-block:: none
 
              startup.mode.copy.existing.namespace.regex=stats\.page.*
 
-          The "\\" character in the example above escapes the "." character
+          The "\" character in the example above escapes the "." character
           that follows it in the regular expression. For more information on
           how to build regular expressions, see the Java API documentation on
           `Patterns <https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html>`__.
@@ -155,9 +154,8 @@ Settings
      - | **Type:** boolean
        |
        | **Description:**
-       | When set to ``true``, 
-         the connector sets the copy existing aggregation 
-         to use temporary disk storage. 
+       | When set to ``true``, the connector uses temporary disk storage
+         for the copy existing aggregation.
        | **Default**: ``true``
        | **Accepted Values**: ``true`` or ``false``
 

--- a/source/source-connector/usage-examples/copy-existing-data.txt
+++ b/source/source-connector/usage-examples/copy-existing-data.txt
@@ -62,7 +62,7 @@ specifying the following configuration options in your source connector:
 
    database=shopping
    collection=customers
-   copy.existing=true
+   startup.mode=copy_existing
 
 Your source connector copies your collection by creating change event documents
 that describe inserting each document into your collection. 
@@ -72,8 +72,8 @@ that describe inserting each document into your collection.
 To learn more about change event documents, see the
 :ref:`Change Streams <source-connector-fundamentals-change-event>` guide.
 
-To learn more about the ``copy.existing`` option, see
-:ref:`<source-configuration-copy-existing>` in the {+mkc+}.
+To learn more about the ``startup.mode`` option, see
+:ref:`<source-configuration-startup>`.
 
 .. _source-usage-example-copy-existing-data-mask-data:
 
@@ -81,16 +81,16 @@ Filter Data
 ~~~~~~~~~~~
 
 You can filter data by specifying an aggregation pipeline in the 
-``copy.existing.pipeline`` option of your source connector configuration. The
+``startup.mode.copy.existing.pipeline`` option of your source connector configuration. The
 following configuration specifies an aggregation pipeline that matches all
 documents with "Mexico" in the ``country`` field:
 
 .. code-block:: properties
 
-   copy.existing.pipeline=[{ "$match": { "country": "Mexico" } }]
+   startup.mode.copy.existing.pipeline=[{ "$match": { "country": "Mexico" } }]
 
-To learn more about  the ``copy.existing.pipeline`` option, see
-:ref:`<source-configuration-copy-existing>` in the {+mkc+}.
+To learn more about  the ``startup.mode.copy.existing.pipeline`` option, see
+:ref:`<source-configuration-startup>`.
 
 To learn more about aggregation pipelines, see the following resources:
 
@@ -101,7 +101,7 @@ To learn more about aggregation pipelines, see the following resources:
 Specify the Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Your source connector configuration to copy the ``customers`` collection should
+Your final source connector configuration to copy the ``customers`` collection should
 look like this:
 
 .. literalinclude:: /includes/usage-examples/copy/source.properties

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -12,6 +12,7 @@ What's New
 
 Learn what's new by version:
 
+* :ref:`Version 1.9 <kafka-connector-whats-new-1.9>`
 * :ref:`Version 1.8.1 <kafka-connector-whats-new-1.8.1>`
 * :ref:`Version 1.8 <kafka-connector-whats-new-1.8>`
 * :ref:`Version 1.7 <kafka-connector-whats-new-1.7>`
@@ -23,6 +24,19 @@ Learn what's new by version:
 * :ref:`Version 1.2 <kafka-connector-whats-new-1.2>`
 * :ref:`Version 1.1 <kafka-connector-whats-new-1.1>`
 * :ref:`Version 1.0 <kafka-connector-whats-new-1.0>`
+
+.. _kafka-connector-whats-new-1.9:
+
+What's New in 1.9
+-----------------
+
+- Introduced ``startup.mode=timestamp`` setting that allows you to
+  start a Change Stream at a specific timestamp by setting the new
+  ``startup.mode.timestamp.start.at.operation.time`` property.
+- Deprecated the ``copy.existing`` property and all ``copy.existing.*``
+  properties. You should use ``startup.mode=copy_existing`` and
+  ``startup.mode.copy.existing.*`` properties to configure the copy existing
+  feature.
 
 .. _kafka-connector-whats-new-1.8.1:
 
@@ -98,7 +112,7 @@ Source Connector
 - Added support for the
   :manual:`allow disk use </reference/command/aggregate/#std-label-aggregate-cmd-allowDiskUse>`
   field of the {+query-api+} in the copy existing aggregation with the
-  ``copy.existing.allow.disk.use`` :ref:`configuration property <source-configuration-startup>`
+  ``copy.existing.allow.disk.use`` :ref:`configuration property <source-configuration-copy-existing>`
 - Added support for `Avro schema namespaces <https://avro.apache.org/docs/current/spec.html#names>`__
   in the ``output.schema.value`` and ``output.schema.key``
   :ref:`configuration properties <source-configuration-output-format>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -98,7 +98,7 @@ Source Connector
 - Added support for the
   :manual:`allow disk use </reference/command/aggregate/#std-label-aggregate-cmd-allowDiskUse>`
   field of the {+query-api+} in the copy existing aggregation with the
-  ``copy.existing.allow.disk.use`` :ref:`configuration property <source-configuration-copy-existing>`
+  ``copy.existing.allow.disk.use`` :ref:`configuration property <source-configuration-startup>`
 - Added support for `Avro schema namespaces <https://avro.apache.org/docs/current/spec.html#names>`__
   in the ``output.schema.value`` and ``output.schema.key``
   :ref:`configuration properties <source-configuration-output-format>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-26355
**Staging**
Main page: https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-26355-start-specified-time/source-connector/configuration-properties/startup/
Old page (added admonition): https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-26355-start-specified-time/source-connector/configuration-properties/copy-existing/
What's New: https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-26355-start-specified-time/whats-new/#std-label-kafka-connector-whats-new-1.9
Usage example: https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-26355-start-specified-time/source-connector/usage-examples/copy-existing-data/#std-label-source-usage-example-copy-existing-data
All properties subsection: https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-26355-start-specified-time/source-connector/configuration-properties/all-properties/#startup-mode

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
