### PR TITLE
DOCSP-26384: remove insert write strategy from v1.0-1.5 docs

### DIFF
--- a/source/sink-connector/configuration-properties/write-strategies.txt
+++ b/source/sink-connector/configuration-properties/write-strategies.txt
@@ -50,16 +50,6 @@ Strategies
        | 
        | This is the default value for the ``writemodel.strategy`` configuration setting.
 
-   * - | **InsertOneDefaultStrategy**
-       | 
-     - | **Description:**
-       | Insert each sink record into MongoDB as a document. 
-       | Apply the following configuration to your sink connector to specify this setting: 
-       
-       .. code-block:: properties
-           
-          writemodel.strategy=com.mongodb.kafka.connect.sink.writemodel.strategy.InsertOneDefaultStrategy
-
    * - | **ReplaceOneDefaultStrategy**
        |
      - | **Description:**


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-26384
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/v1.5/sink-connector/configuration-properties/write-strategies/#strategies

removed `InsertOneDefaultStrategy`