### PR TITLE
DOCSP-26559: clarify what full document property does

### DIFF
--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -86,6 +86,16 @@ Settings
          stream document. When set to ``true``, the connector
          automatically sets the ``change.stream.full.document`` property to
          ``updateLookup`` to receive the updated documents.
+       
+       .. note::
+          
+          This change stream option is a helper that returns the
+          ``fullDocument`` field from the full change stream document.
+          You must set pipeline configurations against the change stream
+          event, not the ``fullDocument``. To learn how to
+          configure a pipeline against a change stream event, see the
+          :ref:`Custom Pipeline <source-usage-example-custom-pipeline>` usage example.
+
        |
        | **Default**: ``false``
        | **Accepted Values**: ``true`` or ``false``

--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -82,19 +82,18 @@ Settings
      - | **Type:** boolean
        |
        | **Description:**
-       | Whether to publish the changed document instead of the full change
-         stream document. When set to ``true``, the connector
-         automatically sets the ``change.stream.full.document`` property to
-         ``updateLookup`` to receive the updated documents.
+       | Whether to return only the ``fullDocument`` field from the full
+         change stream document. The ``fullDocument`` field contains the
+         most current version of the updated document. When set to
+         ``true``, the connector automatically sets the
+         ``change.stream.full.document`` property to ``updateLookup`` to
+         receive the updated documents.
        
-       .. note::
+       .. important::
           
-          This change stream option is a helper that returns the
-          ``fullDocument`` field from the full change stream document.
           You must set pipeline configurations against the change stream
           event, not the ``fullDocument``. To learn how to
-          configure a pipeline against a change stream event, see the
-          :ref:`Custom Pipeline <source-usage-example-custom-pipeline>` usage example.
+          configure a pipeline, see the ``pipeline`` setting description.
 
        |
        | **Default**: ``false``

--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -41,12 +41,14 @@ Settings
        |
        | **Description:**
        | An array of aggregation pipelines to run in your change stream.
+         You must set ``pipeline`` configurations against the full change stream
+         event document, not the ``fullDocument`` field.
 
        .. example::
 
           .. code-block:: none
 
-             [{"$match": {"operationType": "insert"}}, {"$addFields": {"Kafka": "Rules!"}}]
+             [{"$match": { "$and": [{"fullDocument.eventId": 1404 }, {"operationType": "insert"}] } }]
 
        .. tip:: Additional Examples
 
@@ -84,18 +86,11 @@ Settings
        | **Description:**
        | Whether to return only the ``fullDocument`` field from the full
          change stream document. The ``fullDocument`` field contains the
-         most current version of the updated document. When set to
-         ``true``, the connector automatically sets the
+         most current version of the updated document.
+       | When set to ``true``, the connector automatically sets the
          ``change.stream.full.document`` property to ``updateLookup`` to
          receive the updated documents.
-       
-       .. important::
-          
-          You must set pipeline configurations against the change stream
-          event, not the ``fullDocument``. To learn how to
-          configure a pipeline, see the ``pipeline`` setting description.
 
-       |
        | **Default**: ``false``
        | **Accepted Values**: ``true`` or ``false``
 

--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -41,14 +41,14 @@ Settings
        |
        | **Description:**
        | An array of aggregation pipelines to run in your change stream.
-         You must set ``pipeline`` configurations against the full change stream
+         You must configure this setting for the change stream
          event document, not the ``fullDocument`` field.
 
        .. example::
 
           .. code-block:: none
 
-             [{"$match": { "$and": [{"fullDocument.eventId": 1404 }, {"operationType": "insert"}] } }]
+             [{"$match": { "$and": [{"operationType": "insert"}, {"fullDocument.eventId": 1404 }] } }]
 
        .. tip:: Additional Examples
 
@@ -84,12 +84,15 @@ Settings
      - | **Type:** boolean
        |
        | **Description:**
-       | Whether to return only the ``fullDocument`` field from the full
-         change stream document. The ``fullDocument`` field contains the
-         most current version of the updated document.
-       | When set to ``true``, the connector automatically sets the
-         ``change.stream.full.document`` property to ``updateLookup`` to
-         receive the updated documents.
+       | Whether to return only the ``fullDocument`` field from the
+         change stream event document produced by any update event. The ``fullDocument`` field
+         contains the most current version of the updated document. To
+         learn more about the ``fullDocument`` field, see the :rapid:`Server
+         manual page on update events </reference/change-events/update/>`.
+       | When set to ``true``, the connector overrides the
+         ``change.stream.full.document`` setting and sets it to
+         ``updateLookup`` so that the ``fullDocument`` field contains
+         updated documents.
 
        | **Default**: ``false``
        | **Accepted Values**: ``true`` or ``false``


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-26559
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-26559-clarify-full-doc/source-connector/configuration-properties/change-stream/#settings
(note in `publish.full.document.only`)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
