### PR TITLE
DOCSP-20912: create material on bulk writes

### DIFF
--- a/source/sink-connector/configuration-properties/connector-message.txt
+++ b/source/sink-connector/configuration-properties/connector-message.txt
@@ -77,25 +77,8 @@ Settings
          When set to ``true``, the default value, the
          connector writes a batch of records as an ordered bulk write
          operation.
-       | To learn more about ordered and unordered
-         bulk write operations, see
-         `Bulk Write Operations <{+connector_driver_url_base+}fundamentals/crud/write-operations/bulk/#order-of-execution>`__
-         in the MongoDB Java driver documentation.
-
-       .. tip:: Performance Benefits
-
-          If you can write your data to MongoDB in any order, use unordered
-          bulk write operations. Unordered bulk writes provide the following
-          benefits: 
-          
-          - MongoDB can execute unordered bulk writes in parallel
-          - If you configured your connector to tolerate errors, unordered bulk writes 
-            help you :ref:`lose less data <kafka-sink-bulk-ordered-data-loss>`.
-
-          To learn more about the performance benefits of unordered
-          bulk write operations, see :manual:`Unordered Operations </reference/method/Bulk/#unordered-operations>`
-          in the MongoDB Manual. 
-
+       | To learn more about bulk write operations, see the :ref:`Write
+         Model Strategies page <sink-connector-bulk-write-ops>`.
        |
        | **Default**: ``true``
        | **Accepted Values**: ``true`` or ``false``

--- a/source/sink-connector/fundamentals/error-handling-strategies.txt
+++ b/source/sink-connector/fundamentals/error-handling-strategies.txt
@@ -88,19 +88,9 @@ option:
 .. warning:: Ordered Bulk Writes Can Result in Skipped Messages
 
    If you set your connector to tolerate errors and use ordered bulk writes, you
-   may lose data. When an ordered bulk write fails, the connector skips the
-   remaining writes in that batch and resumes processing the next batch.
-   
-   If you set your connector to tolerate errors and use unordered bulk writes,
-   you lose less data. Your connector attempts to perform every write in the
-   batch even if some writes fail. 
-   
-   When using unordered bulk writes, ensure you can perform the write operations
-   within each batch in any order.
-
-   To configure your connector to use unordered bulk writes, set the
-   ``bulk.write.ordered`` property to ``false``. To learn more about this
-   property, see the :ref:`<sink-configuration-message-processing>` page.
+   may lose data. If you set your connector to tolerate errors and use unordered bulk writes,
+   you lose less data. To learn more about bulk write operations, see
+   the :ref:`Write Model Strategies page <sink-connector-bulk-write-ops>`.
 
 .. _kafka-sink-errors-dlq:
 

--- a/source/sink-connector/fundamentals/write-strategies.txt
+++ b/source/sink-connector/fundamentals/write-strategies.txt
@@ -49,26 +49,32 @@ Bulk writes group multiple write operations, such as inserts,
 updates, or deletes, together. 
 
 By default, the sink connector performs ordered bulk writes, which
-guarantees the order of data changes. In an ordered bulk write, if any write operations
+guarantee the order of data changes. In an ordered bulk write, if any write operations
 results in an error, the connector skips the remaining writes in that
-batch. Because of this behavior, there are performance benefits to
-using unordered bulk writes, if you can make changes to your data in any
-order. The sink connector can perform unordered bulk writes in parallel, which can increase
-performance. In addition, if you set the ``errors.tolerance`` setting to
-``all`` and any write operation in your bulk write fails, the connector continues to
-perform the remaining write operations in the batch that do not return errors.
+batch.
 
 If you don't need to guarantee the order of data changes, you can
-specify the ``bulk.write.ordered`` setting to perform unordered bulk
-writes instead. To learn more about this setting, see the
-:ref:`Connector Message Processing Properties
-<sink-configuration-message-processing>`.
+set the ``bulk.write.ordered`` setting to ``false`` so that the
+connector performs unordered bulk writes. The sink connector performs
+unordered bulk writes in parallel, which can improve performance.
 
-To learn more about bulk write operations, see the following
-documentation:
+In addition, when you enable unordered bulk writes and set the
+``errors.tolerance`` setting to ``all``, even if any write
+operation in your bulk write fails, the connector continues to
+perform the remaining write operations in the batch that do not return
+errors.
 
-- :manual:`Server manual entry on ordered and unordered bulk operations </reference/method/Bulk/#ordered-and-unordered-bulk-operations>`.
-- `Bulk write operations in Java <{+connector_driver_url_base+}fundamentals/crud/write-operations/bulk/#order-of-execution>`__
+.. tip::
+
+   To learn more about the ``bulk.write.ordered`` setting, see the
+   :ref:`Connector Message Processing Properties
+   <sink-configuration-message-processing>`.
+   
+   To learn more about bulk write operations, see the following
+   documentation:
+
+   - :manual:`Server manual entry on ordered and unordered bulk operations </reference/method/Bulk/#ordered-and-unordered-bulk-operations>`.
+   - `Bulk write operations in Java <{+connector_driver_url_base+}fundamentals/crud/write-operations/bulk/#order-of-execution>`__
 
 How to Specify Write Model Strategies
 -------------------------------------

--- a/source/sink-connector/fundamentals/write-strategies.txt
+++ b/source/sink-connector/fundamentals/write-strategies.txt
@@ -62,7 +62,7 @@ If you don't need to guarantee the order of data changes, you can
 specify the ``bulk.write.ordered`` setting to perform unordered bulk
 writes instead. To learn more about this setting, see the
 :ref:`Connector Message Processing Properties
-<sink-configuration-message-processing-table-start>`.
+<sink-configuration-message-processing>`.
 
 To learn more about bulk write operations, see the following
 documentation:

--- a/source/sink-connector/fundamentals/write-strategies.txt
+++ b/source/sink-connector/fundamentals/write-strategies.txt
@@ -49,20 +49,20 @@ Bulk writes group multiple write operations, such as inserts,
 updates, or deletes, together. 
 
 By default, the sink connector performs ordered bulk writes, which
-guarantees the order of data changes. You can specify the
-``bulk.write.ordered`` setting to change the default behavior to perform
-unordered bulk writes. To learn more about this setting, see the
+guarantees the order of data changes. In an ordered bulk write, if any write operations
+results in an error, the connector skips the remaining writes in that
+batch. Because of this behavior, there are performance benefits to
+using unordered bulk writes, if you can make changes to your data in any
+order. The sink connector can perform unordered bulk writes in parallel, which can increase
+performance. In addition, if you set the ``errors.tolerance`` setting to
+``all`` and any write operation in your bulk write fails, the connector continues to
+perform the remaining write operations in the batch that do not return errors.
+
+If you don't need to guarantee the order of data changes, you can
+specify the ``bulk.write.ordered`` setting to perform unordered bulk
+writes instead. To learn more about this setting, see the
 :ref:`Connector Message Processing Properties
 <sink-configuration-message-processing-table-start>`.
-
-There are performance benefits from using unordered bulk writes if you
-can make changes to your data in any order. The sink connector can
-perform unordered bulk writes in parallel, which can increase
-performance. In addition, if you set the ``errors.tolerance`` setting to
-``all`` and any write operation fails, the connector continues to
-perform the remaining write operations in the batch, which may result in
-less data loss. In an ordered bulk write, if any write operations
-results in an error, the connector skips the remaining writes in that batch.
 
 To learn more about bulk write operations, see the following
 documentation:

--- a/source/sink-connector/fundamentals/write-strategies.txt
+++ b/source/sink-connector/fundamentals/write-strategies.txt
@@ -35,11 +35,40 @@ To learn how to modify the sink records your connector receives before your
 connector writes them to MongoDB, read the guide on
 :ref:`Sink Connector Post Processors <sink-fundamentals-post-processors>`.
 
-To learn more about bulk writes, see the MongoDB Java driver guide on
-`Bulk Writes <{+connector_driver_url_base+}fundamentals/crud/write-operations/bulk/>`__.
-
 To see a write model strategy implementation, see the source code of the
-:github:`InsertOneDefaultStrategy class <mongodb/mongo-kafka/blob/master/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/InsertOneDefaultStrategy.java>`.
+:github:`InsertOneDefaultStrategy class
+<mongodb/mongo-kafka/blob/master/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/InsertOneDefaultStrategy.java>`.
+
+.. _sink-connector-bulk-write-ops:
+
+Bulk Write Operations
+---------------------
+
+The sink connector writes data to MongoDB using bulk write operations.
+Bulk writes group multiple write operations, such as inserts,
+updates, or deletes, together. 
+
+By default, the sink connector performs ordered bulk writes, which
+guarantees the order of data changes. You can specify the
+``bulk.write.ordered`` setting to change the default behavior to perform
+unordered bulk writes. To learn more about this setting, see the
+:ref:`Connector Message Processing Properties
+<sink-configuration-message-processing-table-start>`.
+
+There are performance benefits from using unordered bulk writes if you
+can make changes to your data in any order. The sink connector can
+perform unordered bulk writes in parallel, which can increase
+performance. In addition, if you set the ``errors.tolerance`` setting to
+``all`` and any write operation fails, the connector continues to
+perform the remaining write operations in the batch, which may result in
+less data loss. In an ordered bulk write, if any write operations
+results in an error, the connector skips the remaining writes in that batch.
+
+To learn more about bulk write operations, see the following
+documentation:
+
+- :manual:`Server manual entry on ordered and unordered bulk operations </reference/method/Bulk/#ordered-and-unordered-bulk-operations>`.
+- `Bulk write operations in Java <{+connector_driver_url_base+}fundamentals/crud/write-operations/bulk/#order-of-execution>`__
 
 How to Specify Write Model Strategies
 -------------------------------------

--- a/source/sink-connector/fundamentals/write-strategies.txt
+++ b/source/sink-connector/fundamentals/write-strategies.txt
@@ -49,9 +49,9 @@ Bulk writes group multiple write operations, such as inserts,
 updates, or deletes, together. 
 
 By default, the sink connector performs ordered bulk writes, which
-guarantee the order of data changes. In an ordered bulk write, if any write operations
-results in an error, the connector skips the remaining writes in that
-batch.
+guarantee the order of data changes. In an ordered bulk write, if any
+write operation results in an error, the connector skips the remaining
+writes in that batch.
 
 If you don't need to guarantee the order of data changes, you can
 set the ``bulk.write.ordered`` setting to ``false`` so that the


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-20912
Staging:
- [Bulk write operations material](https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-20912-bulk-ops-pg/sink-connector/fundamentals/write-strategies/#bulk-write-operations)
- [admonition on Error Handling fundamentals pg](https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-20912-bulk-ops-pg/sink-connector/fundamentals/error-handling-strategies/#tolerate-all-errors)
- [admonition under bulk.write.ordered setting](https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-20912-bulk-ops-pg/sink-connector/configuration-properties/error-handling/#settings)

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST? **ambiguous target to settings table, still leads to correct place**
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
