### PR TITLE
list format fix

### DIFF
--- a/source/source-connector/configuration-properties/startup.txt
+++ b/source/source-connector/configuration-properties/startup.txt
@@ -80,11 +80,12 @@ Settings
          Change Stream parameters, see the :rapid:`Server manual entry </reference/operator/aggregation/changeStream/>`.
        | **Default**: ``""``
        | **Accepted Values**:
-       | * An integer number of seconds since the
+       
+         - An integer number of seconds since the
            Epoch in decimal format (for example, ``30``)
-       | * An instant in the ISO-8601 format with one second precision (for example,
+         - An instant in the ISO-8601 format with one second precision (for example,
            ``1970-01-01T00:00:30Z``)
-       | * A BSON Timestamp in the canonical extended JSON (v2) format
+         - A BSON Timestamp in the canonical extended JSON (v2) format
            (for example, ``{"$timestamp": {"t": 30, "i": 0}}``)
 
    * - | **startup.mode.copy.existing.namespace.regex**


### PR DESCRIPTION
https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/startup-list-fix/source-connector/configuration-properties/startup/#std-label-source-configuration-startup:~:text=startup.mode.timestamp.start.at.operation.time