### PR TITLE
DOCS-15819: Remove m1 incompatibility notice in quickstart

### DIFF
--- a/source/includes/m1-incompatibility.rst
+++ b/source/includes/m1-incompatibility.rst
@@ -1,4 +1,0 @@
-.. important::
-
-   This tutorial is currently incompatible with Apple M1 CPUs. We plan to
-   release a new version once the compatibility issues have been fixed.

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -18,8 +18,6 @@ Overview
 This guide shows you how to configure the {+connector+} to send data between MongoDB
 and {+kafka+}.
 
-.. include:: /includes/m1-incompatibility.rst
-
 After completing this guide, you should understand how to use the {+kafka-connect+}
 REST API to configure {+connector+}s to read data from MongoDB and write it to a
 Kafka topic, and to read data from a Kafka topic and write it to MongoDB.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

Applies to docs v1.8 and later per the ticket description.

JIRA - <https://jira.mongodb.org/browse/DOCS-15819>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCS-15819/quick-start/ (the M1 admonition should no longer appear)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
