### PR TITLE
DOCSP-28267 Incorrect link

### DIFF
--- a/source/sink-connector/configuration-properties.txt
+++ b/source/sink-connector/configuration-properties.txt
@@ -39,41 +39,41 @@ See the following categories for a list of related configuration properties:
    * - Category
      - Description
 
-   * - :doc:`MongoDB Connection Properties </sink-connector/configuration-properties/mongodb-connection>`
+   * - :ref:`sink-configuration-mongodb-connection`
      - Specify how to connect to your MongoDB cluster.
 
-   * - :doc:`MongoDB Namespace Mapping Properties </sink-connector/configuration-properties/mongodb-namespace>`
+   * - :ref:`sink-configuration-namespace-mapping`
      - Specify where to sink your data.
 
-   * - :doc:`Kafka Topic Properties </sink-connector/configuration-properties/kafka-topic>`
+   * - :ref:`sink-configuration-topic-properties`
      - Specify the Kafka topics to which the connector should subscribe.
 
-   * - :doc:`Sink Connector Message Processing Properties </sink-connector/configuration-properties/connector-message>`
+   * - :ref:`sink-configuration-message-processing`
      - Set batch size, rate limiting, and number of parallel tasks.
 
-   * - :doc:`Sink Connector Error Handling Properties </sink-connector/configuration-properties/error-handling>`
+   * - :ref:`sink-configuration-error-handling`
      - Specify how to respond to errors and configure the dead letter queue.
 
-   * - :doc:`Connector Post-processor Properties </sink-connector/configuration-properties/post-processors>`
+   * - :ref:`sink-configuration-post-processors`
      - Specify transformations of Kafka topic data.
 
-   * - :doc:`Connector Id Strategy Properties </sink-connector/configuration-properties/id-strategy>`
+   * - :ref:`sink-configuration-id-strategy`
      - Specify how the connector generates document ids.
 
    * - :ref:`sink-configuration-write-model-strategy`
      - Specify how the connector writes data to MongoDB.
 
-   * - :doc:`Topic Override Properties </sink-connector/configuration-properties/topic-override>`
+   * - :ref:`sink-configuration-topic-override`
      - Override how the connector processes data on specific Kafka topics.
 
-   * - :doc:`Change Data Capture Properties </sink-connector/configuration-properties/cdc>`
+   * - :ref:`sink-configuration-change-data-capture`
      - Specify how the connector captures CDC events from a Kafka topic.
 
-   * - :doc:`Time Series Properties </sink-connector/configuration-properties/time-series>`
+   * - :ref:`sink-configuration-time-series`
      - Configure the connector to sink data to a MongoDB time series
        collection.
 
-   * - :doc:`All Properties </sink-connector/configuration-properties/all-properties>`
+   * - :ref:`sink-configuration-all-properties`
      - View all preceding categories of configuration properties on one page.
 
 See the `Confluent Sink Connector documentation <https://docs.confluent.io/current/installation/configuration/connect/sink-connect-configs.html>`__

--- a/source/sink-connector/configuration-properties.txt
+++ b/source/sink-connector/configuration-properties.txt
@@ -60,7 +60,7 @@ See the following categories for a list of related configuration properties:
    * - :doc:`Connector Id Strategy Properties </sink-connector/configuration-properties/id-strategy>`
      - Specify how the connector generates document ids.
 
-   * - :doc:`Connector Write Model Strategy Properties </sink-connector/configuration-properties/post-processors>`
+   * - :ref:`sink-configuration-write-model-strategy`
      - Specify how the connector writes data to MongoDB.
 
    * - :doc:`Topic Override Properties </sink-connector/configuration-properties/topic-override>`


### PR DESCRIPTION
# Pull Request Info

Corrected a link that was directing to the wrong page
Updated :doc: tags to :ref: tags

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-28267
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-28267-incorrect-link/sink-connector/configuration-properties/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
