### PR TITLE
DOCPS-28585: fix tombstone on delete config setting name

### DIFF
--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -128,7 +128,7 @@ Settings
        | **Default**: ``false``
        | **Accepted Values**: ``true`` or ``false``
 
-   * - | **publish.full.document.only.tombstones.on.delete**
+   * - | **publish.full.document.only.tombstone.on.delete**
      - | **Type:** boolean
        |
        | **Description:**


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-28585>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-28585-tombstone-fix/source-connector/configuration-properties/change-stream/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
