### PR TITLE
typo fixes surfaced by script

### DIFF
--- a/source/monitoring.txt
+++ b/source/monitoring.txt
@@ -77,7 +77,7 @@ to satisfy those use cases:
 
    * - You need to know if your MongoDB performance is getting slower
        over time.
-     - Use the ``in-task-put-duration-ms`` metric to initally diagnose
+     - Use the ``in-task-put-duration-ms`` metric to initially diagnose
        a slowdown.
 
        Use the following metrics to further diagnose any issues:
@@ -345,7 +345,7 @@ To view these metrics with {+jconsole+}, perform the following actions:
 
             Notice that the ``{+metrics-path+}.sink-task-metrics.sink-task-0.records``
             attribute has a value of ``0``. This value indicates that
-            your sink task has not recieved any records from {+kafka+}.
+            your sink task has not received any records from {+kafka+}.
 
          .. step:: Continue the Quick Start.
 

--- a/source/tutorials/migrate-time-series.txt
+++ b/source/tutorials/migrate-time-series.txt
@@ -66,7 +66,7 @@ Migrate a Collection to a Time Series Collection
 
    .. step:: Configure the Source Connector
 
-      In a seperate terminal window, create an interactive shell session on the
+      In a separate terminal window, create an interactive shell session on the
       tutorial Docker container downloaded for the Tutorial Setup using
       the following command:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -182,7 +182,7 @@ What's New in 1.6
 
   .. note::
 
-     Starting from Feburary 2022, the **Versioned API** is known the **{+stable-api+}**.
+     Starting from February 2022, the **Versioned API** is known the **{+stable-api+}**.
      All concepts and features remain the same with this naming change.
 
 - Added error handling properties for the
@@ -395,7 +395,7 @@ Sink Connector
 
 - Added support for the ``topics.regex`` property
 - Updated to ignore unused source record key or value fields
-- Added validation for the connection using ``MongoSìnkConnector.validate``
+- Added validation for the connection using ``MongoSinkConnector.validate``
 
 Source Connector
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Ran the alas_but_one.py script in this repo.

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
