### PR TITLE
DOCSP-29589 Update pipeline default value

### DIFF
--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -56,7 +56,7 @@ Settings
           - :ref:`<source-usage-example-custom-pipeline>`
           - :ref:`<source-usage-example-multiple-sources>`
 
-       | **Default**: ``[]``
+       | **Default**: ``"[]"``
        | **Accepted Values**: Valid aggregation pipeline stage
 
    * - | **change.stream.full.document**


### PR DESCRIPTION
# Pull Request Info

We received feedback stating that the default value for the "pipeline" change stream setting is incorrect. The [source code](https://github.com/mongodb/mongo-kafka/blob/382d72958fc083d75f0ca7fb58855cf45e2636fa/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java#LL202C55-L202C55) confirms the feedback, showing that the default value should be a string rather than an array.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-29589
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kafka-connector/docsworker-xlarge/DOCSP-29589-default-pipeline-value/source-connector/configuration-properties/change-stream/#settings

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
