### PR TITLE
add redirect bc json page doesnt exist before 1.3

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -36,6 +36,7 @@ raw: ${prefix}/ -> ${base}/current/
 [*-v1.2]: ${prefix}/${version}/sink-connector/fundamentals/error-handling-strategies -> ${base}/${version}/
 [*-v1.2]: ${prefix}/${version}/source-connector/usage-examples/multiple-sources/ -> ${base}/${version}/
 [*-v1.2]: ${prefix}/${version}/source-connector/configuration-properties/output-format/ -> ${base}/${version}/
+[*-v1.2]: ${prefix}/${version}/source-connector/fundamentals/json-formatters/ -> ${base}/${version}/
 [*-v1.2]: ${prefix}/${version}/sink-connector/configuration-properties/error-handling/ -> ${base}/${version}/
 [*-v1.2]: ${prefix}/${version}/source-connector/configuration-properties/error-handling/ -> ${base}/${version}/
 [*-v1.2]: ${prefix}/${version}/source/source-connector/usage-examples/schema/ -> ${base}/${version}/


### PR DESCRIPTION
Creating a new redirect entry because the JSON formatter setting didn't get implemented until v1.3, so the new page should redirect to base for v1.2 and earlier.