### PR TITLE
DOCSP-31502: regex topic namespace mapping

### DIFF
--- a/source/source-connector/configuration-properties/kafka-topic.txt
+++ b/source/source-connector/configuration-properties/kafka-topic.txt
@@ -79,14 +79,9 @@ Settings
           You can specify complex mappings by using the
           ``topic.namespace.map`` property. This property supports regex
           and wildcard matching. To learn more about these behaviors and
-          view examples, see the following usage examples:
-
-          - :ref:`Topic Namespace Map
-            <topic-naming-namespace-map-example>`
-          - :ref:`Topic Namespace Map with Regular Expressions
-            <topic-naming-namespace-map-regex-example>`
-          - :ref:`Topic Namespace Map with Wildcard
-            <topic-naming-namespace-map-wildcard-example>`
+          view examples, see the :ref:`Topic Namespace Map
+          <topic-naming-namespace-map>` section of the Topic Naming
+          page.
 
        | **Default**: ``""``
        | **Accepted Values**: A valid JSON object

--- a/source/source-connector/configuration-properties/kafka-topic.txt
+++ b/source/source-connector/configuration-properties/kafka-topic.txt
@@ -80,7 +80,7 @@ Settings
           view examples, see the following Usage Examples:
 
           - :ref:`Topic Namespace Map Example <topic-naming-namespace-map-example>`
-          - :ref:`Topic Namespace Map with Regex Example <topic-naming-namespace-map-regex-example>`
+          - :ref:`Topic Namespace Map with Regular Expressions Example <topic-naming-namespace-map-regex-example>`
           - :ref:`Topic Namespace Map with Wildcard Example <topic-naming-namespace-map-wildcard-example>`
 
        | **Default**: ``""``

--- a/source/source-connector/configuration-properties/kafka-topic.txt
+++ b/source/source-connector/configuration-properties/kafka-topic.txt
@@ -71,51 +71,17 @@ Settings
        | Specifies a JSON mapping between change stream document 
          :manual:`namespaces </reference/glossary/#std-term-namespace>`
          and topic names.
+       
+       .. tip:: Namespace Mapping Behavior
 
-       .. example::
+          You can specify complex mappings by specifying the
+          ``topic.namespace.map`` property. This property supports regex
+          and wildcard matching. To learn more about these behaviors and
+          view examples, see the following Usage Examples:
 
-          The following mapping instructs the connector to perform the following
-          actions:
-
-          - Publish change stream documents originating from the
-            ``myDb.myColl`` MongoDB collection to the ``topicOne`` Kafka topic.
-          - Publish change stream documents originating from the
-            ``myDb`` MongoDB database and a collection other than ``myColl``
-            to the Kafka topic ``topicTwo.<collectionName>``.
-          - Publish change stream documents originating from the ``myDb``
-            MongoDB database that do not bear a collection name to
-            the ``topicTwo`` Kafka topic.
-
-          .. code-block:: properties
-             :copyable: false
-
-             topic.namespace.map={"myDb.myColl": "topicOne", "myDb": "topicTwo"}
-
-          The following examples show which topic the connector sends
-          different change stream documents to using the preceding mapping:
-
-          - A change stream document originating from the ``myDb`` database
-            and the ``myColl`` collection publishes to the
-            ``topicOne`` topic.
-          - A change stream document originating from the ``myDb`` database
-            and the ``newColl`` collection publishes to the
-            ``topicTwo.newColl`` topic.
-          - A change stream document originating from dropping the
-            ``myDb`` database, which does not bear a collection name,
-            publishes to the ``topicTwo`` topic.
-
-       | You can use the ``"*"`` wildcard character to match change stream
-         document namespaces.
-
-       .. example::
-
-          The following mapping instructs the connector to publish all change
-          stream documents to the ``topicThree`` topic:
-
-          .. code-block:: properties
-             :copyable: false
-
-             topic.namespace.map={"*": "topicThree"}
+          - :ref:`Topic Namespace Map Example <topic-naming-namespace-map-example>`
+          - :ref:`Topic Namespace Map with Regex Example <topic-naming-namespace-map-regex-example>`
+          - :ref:`Topic Namespace Map with Wildcard Example <topic-naming-namespace-map-wildcard-example>`
 
        | **Default**: ``""``
        | **Accepted Values**: A valid JSON object

--- a/source/source-connector/configuration-properties/kafka-topic.txt
+++ b/source/source-connector/configuration-properties/kafka-topic.txt
@@ -79,14 +79,14 @@ Settings
           You can specify complex mappings by using the
           ``topic.namespace.map`` property. This property supports regex
           and wildcard matching. To learn more about these behaviors and
-          view examples, see the following Usage Examples:
+          view examples, see the following usage examples:
 
           - :ref:`Topic Namespace Map
-            <topic-naming-namespace-map-example>` usage example
+            <topic-naming-namespace-map-example>`
           - :ref:`Topic Namespace Map with Regular Expressions
-            <topic-naming-namespace-map-regex-example>` usage example
+            <topic-naming-namespace-map-regex-example>`
           - :ref:`Topic Namespace Map with Wildcard
-            <topic-naming-namespace-map-wildcard-example>` usage example
+            <topic-naming-namespace-map-wildcard-example>`
 
        | **Default**: ``""``
        | **Accepted Values**: A valid JSON object

--- a/source/source-connector/configuration-properties/kafka-topic.txt
+++ b/source/source-connector/configuration-properties/kafka-topic.txt
@@ -43,7 +43,8 @@ Settings
 
        .. seealso::
 
-          :ref:`Topic Naming Prefix Usage Example <source-usage-example-topic-naming>`
+          :ref:`Topic Naming Prefix <source-usage-example-topic-naming>`
+          usage example
 
        | **Default**: ``""``
        | **Accepted Values**: A string composed of ASCII alphanumeric
@@ -58,7 +59,8 @@ Settings
 
        .. seealso::
 
-          :ref:`Topic Naming Suffix Usage Example <source-usage-example-topic-naming>`
+          :ref:`Topic Naming Suffix <source-usage-example-topic-naming>`
+          usage example
 
        | **Default**: ``""``
        | **Accepted Values**: A string composed of ASCII alphanumeric
@@ -74,14 +76,17 @@ Settings
        
        .. tip:: Namespace Mapping Behavior
 
-          You can specify complex mappings by specifying the
+          You can specify complex mappings by using the
           ``topic.namespace.map`` property. This property supports regex
           and wildcard matching. To learn more about these behaviors and
           view examples, see the following Usage Examples:
 
-          - :ref:`Topic Namespace Map Example <topic-naming-namespace-map-example>`
-          - :ref:`Topic Namespace Map with Regular Expressions Example <topic-naming-namespace-map-regex-example>`
-          - :ref:`Topic Namespace Map with Wildcard Example <topic-naming-namespace-map-wildcard-example>`
+          - :ref:`Topic Namespace Map
+            <topic-naming-namespace-map-example>` usage example
+          - :ref:`Topic Namespace Map with Regular Expressions
+            <topic-naming-namespace-map-regex-example>` usage example
+          - :ref:`Topic Namespace Map with Wildcard
+            <topic-naming-namespace-map-wildcard-example>` usage example
 
        | **Default**: ``""``
        | **Accepted Values**: A valid JSON object

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -82,7 +82,7 @@ Topic Namespace Map
 You can configure your source connector to map namespace values to Kafka
 topic names for incoming change event data. Topic namespace maps contain
 **pairs** that are made up of a namespace pattern and a destination
-topic.
+topic name template.
 
 The following sections describe how the connector interprets namespaces
 and maps them to Kafka topics. In addition to directly mapping databases
@@ -92,7 +92,7 @@ and wildcard pairs in topic namespace maps.
 The order of the pairs in your namespace map can affect how the
 connector writes events to your topics. The connector matches namespaces
 in the following order:
- 
+
 1. Pairs with database and collection names in the namespace pattern. To
    learn more about this namespace pattern, see the :ref:`Database and
    Collection Names <topic-naming-namespace-map-example>` example.
@@ -114,8 +114,9 @@ topic namespace map to write change events from these sources to Kafka
 topics.
 
 If the database name or namespace of the change event matches one of the
-fields in the map, the connector publishes the record to the value that
-corresponds to that mapping.
+fields in the map, the connector computes the destination topic name
+based on the topic name template that corresponds to that mapping and
+publishes the event to this topic.
 
 If the database name or namespace of the change event does not match any
 mapping, the connector publishes the record using the default topic naming
@@ -139,8 +140,8 @@ over mappings that only specify the source database name.
 
 The following example shows how to specify the ``topic.namespace.map``
 setting to define a topic namespace mappings from the ``carDb`` database
-to the ``automobiles`` topic and the ``carDb.ev`` namespace to the
-``electricVehicles`` topic:
+to the ``automobiles`` topic name template and the ``carDb.ev``
+namespace to the ``electricVehicles`` topic name template:
 
 .. code-block:: ini
 
@@ -153,8 +154,7 @@ mapping, the connector performs the following actions:
   the connector sets the destination to the  ``electricVehicles`` topic.
 - If the change event came from the database ``carDb`` and a collection
   other than ``ev``, the connector sets the destination to the
-  ``automobiles.<collection name>``
-  topic.
+  ``automobiles.<collection name>`` topic.
 - If the change document came from any database other than ``carDb``, the
   connector sets the destination topic to the default namespace naming
   scheme.
@@ -199,19 +199,19 @@ any other purpose.
    When you create a namespace pattern, ensure that you properly handle
    characters that need escaping. For example, to match
    ``.``, the regex syntax requires that you escape it as ``\.``
-   However, you must escape the backslash ``\`` character as ``\\``.
-   Then, to match ``.`` in your namespace pattern, you must
-   write it as ``\\.``.
+   However, you must escape the backslash ``\`` character as ``\\``
+   according to the JSON syntax. Then, to match ``.`` in your namespace
+   pattern, you must write it as ``\\.``.
 
 This example shows how to specify the ``topic.namespace.map``
 setting so that the connector performs the following mapping:
 
 - Writes events from databases that match a regular expression to the
-  ``industrial{sep_coll}`` topic. The regex pattern matches any
+  ``industrial{sep_coll}`` topic name template. The regex pattern matches any
   namespace with the ``vertical`` database name.
 
 - Writes events from the ``vertical.health`` namespace to the
-  ``healthcare`` topic.
+  ``healthcare`` topic name template.
 
 .. code-block:: ini
 
@@ -231,8 +231,8 @@ following actions:
   ``healthcare`` topic.
 
 - If the change event comes from any other namespaces with the ``vertical``
-  database name, the connector sets the destination to the
-  ``industrial{sep_coll}`` topic. The following examples
+  database name, the connector computes the destination topic based on
+  the ``industrial{sep_coll}`` topic name template. The following examples
   demonstrate this mapping:
 
   - If the change event comes from the ``vertical.wasteManagement``

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -4,26 +4,36 @@
 Topic Naming
 ============
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Overview
+--------
+
 The examples on this page show how to configure your {+source-connector+}
 to customize the name of the topic to which it publishes records.
 
 By default, the MongoDB Kafka source connector publishes change event data
 to a Kafka topic with the same name as the MongoDB **namespace** from which
 the change events originated. A namespace is a string that's composed of the
-database and collection name concatenated with a dot "." character.
+database and collection name concatenated with a dot (``.``) character.
 
 The following examples show different ways that you can customize the
 Kafka topics to which the connector publishes change event data:
 
-- :ref:`Topic Prefix <topic-naming-prefix-example>`
-- :ref:`Topic Suffix <topic-naming-suffix-example>`
-- :ref:`Topic Namespace Map <topic-naming-namespace-map-example>`
-- :ref:`Topic Namespace Map with Wildcard <topic-naming-namespace-map-wildcard-example>`
+- :ref:`Topic Prefix Example <topic-naming-prefix-example>`
+- :ref:`Topic Suffix Example <topic-naming-suffix-example>`
+- :ref:`Topic Namespace Map Example <topic-naming-namespace-map-example>`
+- :ref:`Topic Namespace Map with Regex Example <topic-naming-namespace-map-regex-example>`
+- :ref:`Topic Namespace Map with Wildcard Example <topic-naming-namespace-map-wildcard-example>`
 
 .. _topic-naming-prefix-example:
 
 Topic Prefix Example
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 You can configure your source connector to prepend a string to the
 namespace of the change event data, and publish records to that Kafka
@@ -46,7 +56,7 @@ in the ``test`` database to the Kafka topic named ``myPrefix.test.data``.
 .. _topic-naming-suffix-example:
 
 Topic Suffix Example
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 You can configure your source connector to append a string to the
 namespace of the change event data, and publish records to that Kafka
@@ -69,7 +79,7 @@ in the ``test`` database to the Kafka topic named ``test.data.mySuffix``.
 .. _topic-naming-namespace-map-example:
 
 Topic Namespace Map Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 You can configure your source connector to map namespace values to Kafka
 topic names for incoming change event data.
@@ -117,10 +127,117 @@ mapping, the connector performs the following actions:
   ``topic.suffix`` settings to the destination topic name after it
   performs namespace mapping.
 
+.. _topic-naming-namespace-map-regex-example:
+
+Topic Namespace Map with Regex Example
+--------------------------------------
+
+You can use regular expressions as namespace patterns when specifying a
+topic namespace map. To specify a regular expression in a namespace, start the
+namespace pattern with the solidus (``/``) character. Create the regular
+expression following the syntax and behavior outlined by the
+``java.util.regex.Pattern`` class.
+
+.. important::
+   
+   MongoDB database names cannot contain the ``/`` character. If your
+   namespace contains this character, the connector interprets the
+   namespace as a regex pattern or raises an ``ConnectConfigException``
+   if the ``/`` character is not at the beginning of the namespace.
+
+The connector computes the topic name by doing variable expansion on the
+topic name template. The connector supports the following variables: 
+ 
+- ``db``: The database name from the matching namespace.
+- ``sep``: The value of the ``topic.separator`` configuration property.
+  To learn more about this property, see :ref:`source-configuration-kafka-topic`.
+- ``coll``: The collection name from the matching namespace, or an empty
+  string if there is no collection name.
+- ``sep_coll``: The value of the ``coll`` variable prefixed with the value
+  of the ``sep`` variable if the value of ``coll`` is not empty.
+- ``coll_sep``: The value of the ``coll`` variable suffixed with the
+  value of the ``sep`` variable if the value of ``coll`` is not empty.
+- ``sep_coll_sep``: The value of the ``coll`` variable prefixed and
+  suffixed with the value of the ``sep`` variable if the value of
+  ``coll`` is not empty.
+ 
+You must enclose variables between curly brackets (``{}``) for the connector to
+expand them. You can't use curly brackets in the topic name template for
+any other purpose.
+
+.. important:: Escaping Characters
+
+   You must follow the JSON syntax to create a namespace pattern that includes
+   characters that need escaping. For example, to match
+   ``'.'``, the regex syntax requires that you escape it as ``'\.'``
+   You must escape the reverse solidus ``'\'`` character as ``'\\'``.
+   Consequently, to match ``'.'`` in your namespace pattern, you need to
+   write it as ``'\\.'``.
+ 
+The connector matches namespaces by using the following order:
+ 
+1. Simple pairs with a collection name in the namespace pattern. To
+   learn more about this namespace pattern, see the :ref:`Topic
+   Namespace Map Example <topic-naming-namespace-map-example>`.
+#. Simple pairs without a collection name in the namespace pattern. To
+   learn more about this namespace pattern, see the :ref:`Topic
+   Namespace Map Example <topic-naming-namespace-map-example>`.
+#. Regex pairs in order.
+#. The wildcard pair. To learn more about this namespace pattern, see
+   the :ref:`Topic Namespace Map with Wildcard Example
+   <topic-naming-namespace-map-wildcard-example>`.
+
+This example shows how to specify the ``topic.namespace.map``
+setting to define the following topic namespace mapping:
+
+- Maps a regular expression to the topic ``industrial{sep_coll}``. The
+  regular expression matches any database names that include the string
+  ``'vertical'``, even if the database name has other characters.
+
+- Maps the ``vertical.health`` namespace to the ``healthcare`` topic.
+
+.. code-block:: ini
+
+   topic.namespace.map={"/vertical(?:\\..*)?": "industrial{sep_coll}", "vertical.health": "healthcare"}
+
+Since the ``vertical.health`` namespace mapping takes precedence over
+the regular expression namespace mapping, the connector performs the
+following actions:
+
+- If the change event comes from the database ``vertical`` and
+  collection ``health``, the connector sets the destination to the
+  ``healthcare`` topic.
+
+- If the change event comes from any database that gets
+  matched by the regex, the connector sets the destination to the
+  ``industrial.<collectionName>`` topic. The following examples
+  demonstrate this mapping:
+
+  - If the change event comes from the ``vertical.wasteManagement``
+    namespace, the connector writes to the
+    ``industrial.wasteManagement`` topic.
+
+  - If the change event comes from the ``vertical_auto.batteries``
+    namespace, the connector writes to the
+    ``industrial.batteries`` topic because the database name contains
+    the string ``'vertical'``.
+  
+  - If the change event comes from the ``vertical_auto``
+    database but no specific collection, the connector writes to the
+    ``industrial`` topic.
+
+- If the change document comes from any database that does not get
+  matched by the regex, the connector sets the destination topic to the
+  default namespace naming scheme. 
+
+- If defined, the connector applies the ``topic.prefix`` and
+  ``topic.suffix`` settings to the destination topic name after it
+  performs namespace mapping.
+
 .. _topic-naming-namespace-map-wildcard-example:
 
 Topic Namespace Map with Wildcard Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 
 In addition to specifying database name and namespace in your topic
 namespace map as shown in :ref:`<topic-naming-namespace-map-example>`,

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -28,13 +28,6 @@ Kafka topics to which the connector publishes change event data:
 - :ref:`Topic Suffix <topic-naming-suffix-example>`
 - :ref:`Topic Namespace Map <topic-naming-namespace-map>`
 
-The Topic Namespace Map section contains the following examples for the
-mapping specifications that the ``topic.namespace.map`` supports:
-
-- :ref:`Database and Collection Names <topic-naming-namespace-map-example>`
-- :ref:`Regular Expressions <topic-naming-namespace-map-regex-example>`
-- :ref:`Wildcard <topic-naming-namespace-map-wildcard-example>`
-
 .. _topic-naming-prefix-example:
 
 Topic Prefix

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -206,12 +206,14 @@ any other purpose.
 This example shows how to specify the ``topic.namespace.map``
 setting so that the connector performs the following mapping:
 
-- Writes events from databases that match a regular expression to the
-  ``industrial{sep_coll}`` topic name template. The regex pattern matches any
-  namespace with the ``vertical`` database name.
+- Writes events from databases that match a regular expression to a
+  topic computed from the ``industrial{sep_coll}`` topic name template.
+  The regex pattern matches any namespace with the ``vertical`` database
+  name.
 
-- Writes events from the ``vertical.health`` namespace to the
-  ``healthcare`` topic name template.
+- Writes events from the ``vertical.health`` namespace the
+  ``healthcare`` topic name. In this case, the topic name template and the
+  computed topic name are the same.
 
 .. code-block:: ini
 

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -27,7 +27,7 @@ Kafka topics to which the connector publishes change event data:
 - :ref:`Topic Prefix Example <topic-naming-prefix-example>`
 - :ref:`Topic Suffix Example <topic-naming-suffix-example>`
 - :ref:`Topic Namespace Map Example <topic-naming-namespace-map-example>`
-- :ref:`Topic Namespace Map with Regex Example <topic-naming-namespace-map-regex-example>`
+- :ref:`Topic Namespace Map with Regular Expressions Example <topic-naming-namespace-map-regex-example>`
 - :ref:`Topic Namespace Map with Wildcard Example <topic-naming-namespace-map-wildcard-example>`
 
 .. _topic-naming-prefix-example:
@@ -123,27 +123,26 @@ mapping, the connector performs the following actions:
 - If the change document came from any database other than ``carDb``, the
   connector sets the destination topic to the default namespace naming
   scheme.
-- If defined, the connector applies the ``topic.prefix`` and
-  ``topic.suffix`` settings to the destination topic name after it
-  performs namespace mapping.
+- If you define the ``topic.prefix`` and ``topic.suffix`` settings, the
+  connector applies their values to the destination topic name after it
+  performs the namespace mapping.
 
 .. _topic-naming-namespace-map-regex-example:
 
-Topic Namespace Map with Regex Example
---------------------------------------
+Topic Namespace Map with Regular Expressions Example
+----------------------------------------------------
 
-You can use regular expressions as namespace patterns when specifying a
-topic namespace map. To specify a regular expression in a namespace, start the
-namespace pattern with the solidus (``/``) character. Create the regular
-expression following the syntax and behavior outlined by the
-``java.util.regex.Pattern`` class.
+You can use regular expressions (regex) to specify namespaces within a
+topic namespace map. To use a regular expression in a topic namespace
+map, start the namespace pattern with the forward slash (``/``)
+character. Create the regular expression following the syntax and
+behavior outlined by the ``java.util.regex.Pattern`` class.
 
 .. important::
    
-   MongoDB database names cannot contain the ``/`` character. If your
-   namespace contains this character, the connector interprets the
-   namespace as a regex pattern or raises a ``ConnectConfigException``
-   if the ``/`` character is not at the beginning of the namespace.
+   Because the ``/`` character denotes that the namespace is a
+   regex pattern, the connector raises a ``ConnectConfigException``
+   if the namespace includes this character in a non-regex context.
 
 The connector computes the topic name by doing variable expansion on the
 topic name template. The connector supports the following variables: 
@@ -154,14 +153,15 @@ topic name template. The connector supports the following variables:
 - ``coll``: The collection name from the matching namespace, or an empty
   string if there is no collection name.
 - ``sep_coll``: The value of the ``coll`` variable prefixed with the value
-  of the ``sep`` variable if the value of ``coll`` is not empty.
+  of the ``sep`` variable, or an empty string if the value of ``coll`` is empty.
 - ``coll_sep``: The value of the ``coll`` variable suffixed with the
-  value of the ``sep`` variable if the value of ``coll`` is not empty.
+  value of the ``sep`` variable, or an empty string if the value of ``coll`` is empty.
 - ``sep_coll_sep``: The value of the ``coll`` variable prefixed and
-  suffixed with the value of the ``sep`` variable if the value of
-  ``coll`` is not empty.
+  suffixed with the value of the ``sep`` variable, or an empty string if
+  the value of ``coll`` is empty.
  
-You must enclose variables between curly brackets (``{}``) for the connector to
+If you use any of the previous variables in your topic name template,
+you must enclose them in curly brackets (``{}``) for the connector to
 expand them. You can't use curly brackets in the topic name template for
 any other purpose.
 
@@ -170,11 +170,11 @@ any other purpose.
    You must follow the JSON syntax to create a namespace pattern that includes
    characters that need escaping. For example, to match
    ``'.'``, the regex syntax requires that you escape it as ``'\.'``
-   You must escape the reverse solidus ``'\'`` character as ``'\\'``.
+   You must escape the backslash ``'\'`` character as ``'\\'``.
    Consequently, to match ``'.'`` in your namespace pattern, you must
    write it as ``'\\.'``.
  
-The connector matches namespaces by using the following order:
+The connector matches namespaces in the following order:
  
 1. Pairs with database and collection names in the namespace pattern. To
    learn more about this namespace pattern, see the :ref:`Topic
@@ -188,19 +188,21 @@ The connector matches namespaces by using the following order:
    <topic-naming-namespace-map-wildcard-example>`.
 
 This example shows how to specify the ``topic.namespace.map``
-setting to define the following topic namespace mapping:
+setting so that the connector performs the following mapping:
 
-- Maps a regular expression to the topic ``industrial{sep_coll}``. The
-  regex pattern matches any database names that include the string
-  ``'vertical'``, even if the database name has other characters.
+- Writes events from databases that match a regular expression to the
+  ``industrial{sep_coll}`` topic. The regex pattern matches any database
+  names that include the string ``'vertical'``, even if the database
+  name has other characters.
 
-- Maps the ``vertical.health`` namespace to the ``healthcare`` topic.
+- Writes events from the ``vertical.health`` collection to the
+  ``healthcare`` topic.
 
 .. code-block:: ini
 
    topic.namespace.map={"/vertical(?:\\..*)?": "industrial{sep_coll}", "vertical.health": "healthcare"}
 
-Since the ``vertical.health`` namespace mapping takes precedence over
+Because the ``vertical.health`` namespace mapping takes precedence over
 the regular expression namespace mapping, the connector performs the
 following actions:
 
@@ -208,8 +210,8 @@ following actions:
   collection ``health``, the connector sets the destination to the
   ``healthcare`` topic.
 
-- If the change event comes from any database that gets
-  matched by the regex, the connector sets the destination to the
+- If the change event comes from any database that matches the regex,
+  the connector sets the destination to the
   ``industrial.<collectionName>`` topic. The following examples
   demonstrate this mapping:
 
@@ -226,13 +228,13 @@ following actions:
     database but no specific collection, the connector writes to the
     ``industrial`` topic.
 
-- If the change document comes from any database that does not get
-  matched by the regex, the connector sets the destination topic to the
-  default namespace naming scheme. 
+- If the change document comes from any database that doesn't match the
+  regex pattern, the connector sets the destination topic to the default
+  namespace naming scheme.
 
-- If defined, the connector applies the ``topic.prefix`` and
-  ``topic.suffix`` settings to the destination topic name after it
-  performs namespace mapping.
+- If you define the ``topic.prefix`` and ``topic.suffix`` settings, the
+  connector applies their values to the destination topic name after it
+  performs the namespace mapping.
 
 .. _topic-naming-namespace-map-wildcard-example:
 

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -7,7 +7,7 @@ Topic Naming
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 Overview
@@ -21,14 +21,19 @@ to a Kafka topic with the same name as the MongoDB **namespace** from which
 the change events originated. A namespace is a string that's composed of the
 database and collection name concatenated with a dot (``.``) character.
 
-The following examples show different ways that you can customize the
+The following sections show different ways that you can customize the
 Kafka topics to which the connector publishes change event data:
 
 - :ref:`Topic Prefix <topic-naming-prefix-example>`
 - :ref:`Topic Suffix <topic-naming-suffix-example>`
-- :ref:`Topic Namespace Map <topic-naming-namespace-map-example>`
-- :ref:`Topic Namespace Map with Regular Expressions <topic-naming-namespace-map-regex-example>`
-- :ref:`Topic Namespace Map with Wildcard <topic-naming-namespace-map-wildcard-example>`
+- :ref:`Topic Namespace Map <topic-naming-namespace-map>`
+
+The Topic Namespace Map section contains the following examples for the
+mapping specifications that the ``topic.namespace.map`` supports:
+
+- :ref:`Database and Collection Names <topic-naming-namespace-map-example>`
+- :ref:`Regular Expressions <topic-naming-namespace-map-regex-example>`
+- :ref:`Wildcard <topic-naming-namespace-map-wildcard-example>`
 
 .. _topic-naming-prefix-example:
 
@@ -76,13 +81,44 @@ setting as shown in the following example:
 Once set, your connector publishes any changes to the ``data`` collection
 in the ``test`` database to the Kafka topic named ``test.data.mySuffix``.
 
-.. _topic-naming-namespace-map-example:
+.. _topic-naming-namespace-map:
 
 Topic Namespace Map
 -------------------
 
 You can configure your source connector to map namespace values to Kafka
-topic names for incoming change event data.
+topic names for incoming change event data. Topic namespace maps contain
+**pairs** that are made up of a namespace pattern and a destination
+topic.
+
+The following sections describe how the connector interprets namespaces
+and maps them to Kafka topics. In addition to directly mapping databases
+and collections to Kafka topics, the connector supports the use of regex
+and wildcard pairs in topic namespace maps.
+
+The order of the pairs in your namespace map can affect how the
+connector writes events to your topics. The connector matches namespaces
+in the following order:
+ 
+1. Pairs with database and collection names in the namespace pattern. To
+   learn more about this namespace pattern, see the :ref:`Database and
+   Collection Names <topic-naming-namespace-map-example>` example.
+#. Pairs with only a database name in the namespace pattern. To
+   learn more about this namespace pattern, see the :ref:`Database and
+   Collection Names <topic-naming-namespace-map-example>` example.
+#. Regex pairs in order. To learn more about this namespace pattern, see
+   the :ref:`Regular Expressions <topic-naming-namespace-map-regex-example>` example.
+#. The wildcard pair. To learn more about this namespace pattern, see
+   the :ref:`Wildcard <topic-naming-namespace-map-wildcard-example>` example.
+
+.. _topic-naming-namespace-map-example:
+
+Database and Collection Names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can specify the names of specific databases and collections within a
+topic namespace map to write change events from these sources to Kafka
+topics.
 
 If the database name or namespace of the change event matches one of the
 fields in the map, the connector publishes the record to the value that
@@ -91,6 +127,12 @@ corresponds to that mapping.
 If the database name or namespace of the change event does not match any
 mapping, the connector publishes the record using the default topic naming
 scheme unless otherwise specified by a different topic naming setting.
+
+.. important::
+   
+   Because the ``/`` character denotes that the namespace is a
+   regex pattern, the connector raises a ``ConnectConfigException``
+   if the namespace includes this character in a non-regex context.
 
 Any mapping that includes both database and collection takes precedence
 over mappings that only specify the source database name.
@@ -118,7 +160,7 @@ mapping, the connector performs the following actions:
   the connector sets the destination to the  ``electricVehicles`` topic.
 - If the change event came from the database ``carDb`` and a collection
   other than ``ev``, the connector sets the destination to the
-  ``automobiles.<collectionName>``
+  ``automobiles.<collection name>``
   topic.
 - If the change document came from any database other than ``carDb``, the
   connector sets the destination topic to the default namespace naming
@@ -129,20 +171,14 @@ mapping, the connector performs the following actions:
 
 .. _topic-naming-namespace-map-regex-example:
 
-Topic Namespace Map with Regular Expressions
---------------------------------------------
+Regular Expressions
+~~~~~~~~~~~~~~~~~~~
 
 You can use a regular expression (regex) within a
 topic namespace map. To use a regular expression, start the namespace
 pattern with the forward slash (``/``) character. Create the regular
 expression following the syntax and behavior specified by the
 ``java.util.regex.Pattern`` class.
-
-.. important::
-   
-   Because the ``/`` character denotes that the namespace is a
-   regex pattern, the connector raises a ``ConnectConfigException``
-   if the namespace includes this character in a non-regex context.
 
 The connector computes the topic name by doing variable expansion on the
 topic name template. The connector supports the following variables: 
@@ -167,62 +203,50 @@ any other purpose.
 
 .. note:: Escaping Characters
 
-   If your namespace pattern includes characters that need escaping,
-   you must prefix these characters with two backslashes (``\\``) in the
-   pattern. For example, to match a period (``'.'``) character, you must
-   write it as ``'\\.'``.
- 
-The connector matches namespaces in the following order:
- 
-1. Pairs with database and collection names in the namespace pattern. To
-   learn more about this namespace pattern, see the :ref:`Topic
-   Namespace Map Example <topic-naming-namespace-map-example>`.
-#. Pairs with only a database name in the namespace pattern. To
-   learn more about this namespace pattern, see the :ref:`Topic
-   Namespace Map Example <topic-naming-namespace-map-example>`.
-#. Regex pairs in order.
-#. The wildcard pair. To learn more about this namespace pattern, see
-   the :ref:`Topic Namespace Map with Wildcard Example
-   <topic-naming-namespace-map-wildcard-example>`.
+   When you create a namespace pattern, ensure that you properly handle
+   characters that need escaping. For example, to match
+   ``.``, the regex syntax requires that you escape it as ``\.``
+   However, you must escape the backslash ``\`` character as ``\\``.
+   Then, to match ``.`` in your namespace pattern, you must
+   write it as ``\\.``.
 
 This example shows how to specify the ``topic.namespace.map``
 setting so that the connector performs the following mapping:
 
 - Writes events from databases that match a regular expression to the
-  ``industrial{sep_coll}`` topic. The regex pattern matches any database
-  names that include the string ``'vertical'``, even if the database
-  name has other characters.
+  ``industrial{sep_coll}`` topic. The regex pattern matches any
+  namespace with the ``vertical`` database name.
 
-- Writes events from the ``vertical.health`` collection to the
+- Writes events from the ``vertical.health`` namespace to the
   ``healthcare`` topic.
 
 .. code-block:: ini
 
    topic.namespace.map={"/vertical(?:\\..*)?": "industrial{sep_coll}", "vertical.health": "healthcare"}
 
+.. note::
+   
+   In this example, the ``topic.separator`` configuration property is
+   ``"."``, the default value.
+
 Because the ``vertical.health`` namespace mapping takes precedence over
 the regular expression namespace mapping, the connector performs the
 following actions:
 
-- If the change event comes from the database ``vertical`` and
-  collection ``health``, the connector sets the destination to the
+- If the change event comes from the ``health`` collection of the
+  ``vertical`` database, the connector sets the destination to the
   ``healthcare`` topic.
 
-- If the change event comes from any database that matches the regex,
-  the connector sets the destination to the
-  ``industrial.<collectionName>`` topic. The following examples
+- If the change event comes from any other namespaces with the ``vertical``
+  database name, the connector sets the destination to the
+  ``industrial{sep_coll}`` topic. The following examples
   demonstrate this mapping:
 
   - If the change event comes from the ``vertical.wasteManagement``
     namespace, the connector writes to the
     ``industrial.wasteManagement`` topic.
-
-  - If the change event comes from the ``vertical_auto.batteries``
-    namespace, the connector writes to the
-    ``industrial.batteries`` topic because the database name contains
-    the string ``'vertical'``.
   
-  - If the change event comes from the ``vertical_auto``
+  - If the change event comes from the ``vertical``
     database but no specific collection, the connector writes to the
     ``industrial`` topic.
 
@@ -236,8 +260,8 @@ following actions:
 
 .. _topic-naming-namespace-map-wildcard-example:
 
-Topic Namespace Map with Wildcard
----------------------------------
+Wildcard
+~~~~~~~~
 
 In addition to specifying database name and namespace in your topic
 namespace map as shown in :ref:`<topic-naming-namespace-map-example>`,

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -24,16 +24,16 @@ database and collection name concatenated with a dot (``.``) character.
 The following examples show different ways that you can customize the
 Kafka topics to which the connector publishes change event data:
 
-- :ref:`Topic Prefix Example <topic-naming-prefix-example>`
-- :ref:`Topic Suffix Example <topic-naming-suffix-example>`
-- :ref:`Topic Namespace Map Example <topic-naming-namespace-map-example>`
-- :ref:`Topic Namespace Map with Regular Expressions Example <topic-naming-namespace-map-regex-example>`
-- :ref:`Topic Namespace Map with Wildcard Example <topic-naming-namespace-map-wildcard-example>`
+- :ref:`Topic Prefix <topic-naming-prefix-example>`
+- :ref:`Topic Suffix <topic-naming-suffix-example>`
+- :ref:`Topic Namespace Map <topic-naming-namespace-map-example>`
+- :ref:`Topic Namespace Map with Regular Expressions <topic-naming-namespace-map-regex-example>`
+- :ref:`Topic Namespace Map with Wildcard <topic-naming-namespace-map-wildcard-example>`
 
 .. _topic-naming-prefix-example:
 
-Topic Prefix Example
---------------------
+Topic Prefix
+------------
 
 You can configure your source connector to prepend a string to the
 namespace of the change event data, and publish records to that Kafka
@@ -55,8 +55,8 @@ in the ``test`` database to the Kafka topic named ``myPrefix.test.data``.
 
 .. _topic-naming-suffix-example:
 
-Topic Suffix Example
---------------------
+Topic Suffix
+------------
 
 You can configure your source connector to append a string to the
 namespace of the change event data, and publish records to that Kafka
@@ -78,8 +78,8 @@ in the ``test`` database to the Kafka topic named ``test.data.mySuffix``.
 
 .. _topic-naming-namespace-map-example:
 
-Topic Namespace Map Example
----------------------------
+Topic Namespace Map
+-------------------
 
 You can configure your source connector to map namespace values to Kafka
 topic names for incoming change event data.
@@ -129,14 +129,14 @@ mapping, the connector performs the following actions:
 
 .. _topic-naming-namespace-map-regex-example:
 
-Topic Namespace Map with Regular Expressions Example
-----------------------------------------------------
+Topic Namespace Map with Regular Expressions
+--------------------------------------------
 
-You can use regular expressions (regex) to specify namespaces within a
-topic namespace map. To use a regular expression in a topic namespace
-map, start the namespace pattern with the forward slash (``/``)
-character. Create the regular expression following the syntax and
-behavior outlined by the ``java.util.regex.Pattern`` class.
+You can use a regular expression (regex) within a
+topic namespace map. To use a regular expression, start the namespace
+pattern with the forward slash (``/``) character. Create the regular
+expression following the syntax and behavior specified by the
+``java.util.regex.Pattern`` class.
 
 .. important::
    
@@ -167,11 +167,9 @@ any other purpose.
 
 .. note:: Escaping Characters
 
-   You must follow the JSON syntax to create a namespace pattern that includes
-   characters that need escaping. For example, to match
-   ``'.'``, the regex syntax requires that you escape it as ``'\.'``
-   You must escape the backslash ``'\'`` character as ``'\\'``.
-   Consequently, to match ``'.'`` in your namespace pattern, you must
+   If your namespace pattern includes characters that need escaping,
+   you must prefix these characters with two backslashes (``\\``) in the
+   pattern. For example, to match a period (``'.'``) character, you must
    write it as ``'\\.'``.
  
 The connector matches namespaces in the following order:
@@ -238,8 +236,8 @@ following actions:
 
 .. _topic-naming-namespace-map-wildcard-example:
 
-Topic Namespace Map with Wildcard Example
------------------------------------------
+Topic Namespace Map with Wildcard
+---------------------------------
 
 In addition to specifying database name and namespace in your topic
 namespace map as shown in :ref:`<topic-naming-namespace-map-example>`,

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -142,7 +142,7 @@ expression following the syntax and behavior outlined by the
    
    MongoDB database names cannot contain the ``/`` character. If your
    namespace contains this character, the connector interprets the
-   namespace as a regex pattern or raises an ``ConnectConfigException``
+   namespace as a regex pattern or raises a ``ConnectConfigException``
    if the ``/`` character is not at the beginning of the namespace.
 
 The connector computes the topic name by doing variable expansion on the
@@ -191,7 +191,7 @@ This example shows how to specify the ``topic.namespace.map``
 setting to define the following topic namespace mapping:
 
 - Maps a regular expression to the topic ``industrial{sep_coll}``. The
-  regular expression matches any database names that include the string
+  regex pattern matches any database names that include the string
   ``'vertical'``, even if the database name has other characters.
 
 - Maps the ``vertical.health`` namespace to the ``healthcare`` topic.

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -211,7 +211,7 @@ setting so that the connector performs the following mapping:
   The regex pattern matches any namespace with the ``vertical`` database
   name.
 
-- Writes events from the ``vertical.health`` namespace the
+- Writes events from the ``vertical.health`` namespace to the
   ``healthcare`` topic name. In this case, the topic name template and the
   computed topic name are the same.
 

--- a/source/source-connector/usage-examples/topic-naming.txt
+++ b/source/source-connector/usage-examples/topic-naming.txt
@@ -88,7 +88,7 @@ If the database name or namespace of the change event matches one of the
 fields in the map, the connector publishes the record to the value that
 corresponds to that mapping.
 
-If the database name or namespace of the change event do not match any
+If the database name or namespace of the change event does not match any
 mapping, the connector publishes the record using the default topic naming
 scheme unless otherwise specified by a different topic naming setting.
 
@@ -165,21 +165,21 @@ You must enclose variables between curly brackets (``{}``) for the connector to
 expand them. You can't use curly brackets in the topic name template for
 any other purpose.
 
-.. important:: Escaping Characters
+.. note:: Escaping Characters
 
    You must follow the JSON syntax to create a namespace pattern that includes
    characters that need escaping. For example, to match
    ``'.'``, the regex syntax requires that you escape it as ``'\.'``
    You must escape the reverse solidus ``'\'`` character as ``'\\'``.
-   Consequently, to match ``'.'`` in your namespace pattern, you need to
+   Consequently, to match ``'.'`` in your namespace pattern, you must
    write it as ``'\\.'``.
  
 The connector matches namespaces by using the following order:
  
-1. Simple pairs with a collection name in the namespace pattern. To
+1. Pairs with database and collection names in the namespace pattern. To
    learn more about this namespace pattern, see the :ref:`Topic
    Namespace Map Example <topic-naming-namespace-map-example>`.
-#. Simple pairs without a collection name in the namespace pattern. To
+#. Pairs with only a database name in the namespace pattern. To
    learn more about this namespace pattern, see the :ref:`Topic
    Namespace Map Example <topic-naming-namespace-map-example>`.
 #. Regex pairs in order.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -36,8 +36,8 @@ What's New in 1.11
 
 - Added support for regular expressions in the ``topic.namespace.map``
   property. To learn more about this feature and see an example of its
-  use, see the :ref:`Topic Namespace Map with Regular Expressions Example
-  <topic-naming-namespace-map-regex-example>`.
+  use, see the :ref:`Topic Namespace Map with Regular Expressions
+  <topic-naming-namespace-map-regex-example>` usage example.
 
 - Added support for setting a custom delete write model strategy using the
   ``delete.writemodel.strategy`` propery.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -36,8 +36,9 @@ What's New in 1.11
 
 - Added support for regular expressions in the ``topic.namespace.map``
   property. To learn more about this feature and see an example of its
-  use, see the :ref:`Topic Namespace Map with Regular Expressions
-  <topic-naming-namespace-map-regex-example>` usage example.
+  use, see the :ref:`Regular Expressions
+  <topic-naming-namespace-map-regex-example>` usage example in the Topic
+  Naming page.
 
 - Added support for setting a custom delete write model strategy using the
   ``delete.writemodel.strategy`` propery.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -35,7 +35,7 @@ What's New in 1.11
 --------------------
 
 - Added support for regular expressions in the ``topic.namespace.map``
-  property. To learn more about this behavior and view examples, see the
+  property. To learn more about this feature and an example, see the
   :ref:`Topic Namespace Map with Regex Example
   <topic-naming-namespace-map-regex-example>`.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -34,7 +34,10 @@ Learn what's new by version:
 What's New in 1.11
 --------------------
 
-- Added support for regular expressions in the ``topic.namespace.map`` property.
+- Added support for regular expressions in the ``topic.namespace.map``
+  property. To learn more about this behavior and view examples, see the
+  :ref:`Topic Namespace Map with Regex Example
+  <topic-naming-namespace-map-regex-example>`.
 
 - Added support for setting a custom delete write model strategy using the
   ``delete.writemodel.strategy`` propery.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -35,8 +35,8 @@ What's New in 1.11
 --------------------
 
 - Added support for regular expressions in the ``topic.namespace.map``
-  property. To learn more about this feature and an example, see the
-  :ref:`Topic Namespace Map with Regex Example
+  property. To learn more about this feature and see an example of its
+  use, see the :ref:`Topic Namespace Map with Regular Expressions Example
   <topic-naming-namespace-map-regex-example>`.
 
 - Added support for setting a custom delete write model strategy using the


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31502>
Staging - 
[example](https://preview-mongodbrustagir.gatsbyjs.io/kafka-connector/DOCSP-31502-topic-namespace-regex/source-connector/usage-examples/topic-naming/#topic-namespace-map-with-regex-example)
[config property](https://preview-mongodbrustagir.gatsbyjs.io/kafka-connector/DOCSP-31502-topic-namespace-regex/source-connector/configuration-properties/kafka-topic/#:~:text=including%20%22.%22%2C%20%22%2D%22%2C%20and%20%22_%22-,topic.namespace.map,-Type%3A%20string)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
