### PR TITLE
DOCSP-32096: use id in tombstone events

### DIFF
--- a/source/source-connector/configuration-properties/change-stream.txt
+++ b/source/source-connector/configuration-properties/change-stream.txt
@@ -23,6 +23,8 @@ with the {+source-connector+}.
 
 .. include:: /includes/source-config-link.rst
 
+.. _source-configuration-change-stream-list:
+
 Settings
 --------
 
@@ -136,6 +138,19 @@ Settings
          ``publish.full.document.only`` is ``true``.
 
        | **Default**: ``false``
+       | **Accepted Values**: ``true`` or ``false``
+
+   * - | **change.stream.document.key.as.key**
+     - | **Type:** boolean
+       |
+       | **Description:**
+       | Whether to use the document key for the source record key if
+         the document key is present. When this setting is ``true``,
+         tombstone events have the keys of the deleted documents.
+         When this setting is ``false``, tombstone events use
+         the resume token as the source key.
+
+       | **Default**: ``true``
        | **Accepted Values**: ``true`` or ``false``
 
    * - | **collation**

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -41,6 +41,11 @@ What's New in 1.11
 
 - Added the ``UpdateOneDefaultStrategy`` write model strategy.
 
+- Added the ``change.stream.document.key.as.key`` source connector
+  configuration property so tombstone events use the keys of deleted
+  documents as source record keys. To learn more about this property,
+  see the list of :ref:`Change Stream Properties <source-configuration-change-stream-list>`.
+
 - DDL events from Debezium are recorded as no-ops and no longer cause an error.
 
 .. _kafka-connector-whats-new-1.10.1:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kafka-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-32096>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/kafka-connector/DOCSP-32096-tombstone-id-config/source-connector/configuration-properties/change-stream/#:~:text=change.stream.document.key.as.key

[whats new
](https://preview-mongodbrustagir.gatsbyjs.io/kafka-connector/DOCSP-32096-tombstone-id-config/whats-new/#what-s-new-in-1.11)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
