### PR TITLE
DOCSP-48448: Backport to v1.13

### DIFF
--- a/source/introduction/data-formats.txt
+++ b/source/introduction/data-formats.txt
@@ -146,9 +146,9 @@ Avro Schema
 Avro schema is a JSON-based schema definition syntax. Avro schema supports the
 specification of the following groups of data types:
 
-- `Primitive Types <https://avro.apache.org/docs/current/spec.html#schema_primitive>`__
-- `Complex Types <https://avro.apache.org/docs/current/spec.html#schema_complex>`__
-- `Logical Types <https://avro.apache.org/docs/current/spec.html#Logical+Types>`__
+- `Primitive Types <https://avro.apache.org/docs/++version++/specification/#primitive-types>`__
+- `Complex Types <https://avro.apache.org/docs/++version++/specification/#complex-types>`__
+- `Logical Types <https://avro.apache.org/docs/++version++/specification/#logical-types>`__
 
 .. warning:: Unsupported Avro Types
 
@@ -194,7 +194,7 @@ You use Avro schema when you
 :ref:`define a schema for a {+source-connector+} <source-specify-avro-schema>`.
 
 For a list of all Avro schema types, see the
-`Apache Avro specification <https://avro.apache.org/docs/current/spec.html>`__.
+`Apache Avro specification <https://avro.apache.org/docs/++version++/specification/>`__.
 
 .. _kafka-df-avro-encoding:
 
@@ -220,7 +220,7 @@ Avro converter, see the :ref:`Converters <avro-converter-sample-properties>`
 guide. 
 
 To learn more about Avro binary encoding, see
-`this section of the Avro specification <https://avro.apache.org/docs/current/spec.html#Data+Serialization+and+Deserialization>`__. 
+`this section of the Avro specification <https://avro.apache.org/docs/++version++/specification/#data-serialization-and-deserialization>`__. 
 
 .. _kafka-db-byte-arrays:
 

--- a/source/source-connector/usage-examples/schema.txt
+++ b/source/source-connector/usage-examples/schema.txt
@@ -85,18 +85,18 @@ using the following data types:
      - Description
 
    * - **name**
-     - `string <https://avro.apache.org/docs/current/spec.html#schema_primitive>`__
+     - `string <https://avro.apache.org/docs/++version++/specification/#primitive-types>`__
      - | Name of the customer
 
    * - **visits**
-     - `array <https://avro.apache.org/docs/current/spec.html#Arrays>`__
-       of `timestamps <https://avro.apache.org/docs/current/spec.html#Timestamp+%28millisecond+precision%29>`__
+     - `array <https://avro.apache.org/docs/++version++/specification/#arrays>`__
+       of `timestamps <https://avro.apache.org/docs/++version++/specification/#timestamps>`__
      - Dates the customer visited
 
    * - **goods_purchased**
-     - `map <https://avro.apache.org/docs/current/spec.html#Maps>`__
+     - `map <https://avro.apache.org/docs/++version++/specification/#maps>`__
        of string (the assumed type) to
-       `integer <https://avro.apache.org/docs/current/spec.html#schema_primitive>`__
+       `integer <https://avro.apache.org/docs/++version++/specification/#primitive-types>`__
        values
      - Names of goods and quantity of each item the customer purchased
 


### PR DESCRIPTION
This PR cherry-picks commit f095841 from master into v1.13.

JIRA - <https://jira.mongodb.org/browse/DOCSP-48448>

Staging:

 - <https://deploy-preview-215--docs-kafka-connector.netlify.app/> top most section
- [Data Formats](https://deploy-preview-215--docs-kafka-connector.netlify.app//introduction/data-formats/)
- [Specify a Schema](https://deploy-preview-215--docs-kafka-connector.netlify.app/source-connector/usage-examples/schema/)